### PR TITLE
run qodana only on demand

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -1,27 +1,6 @@
 name: Qodana Scan
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - .github/workflows/qodana.yml
-      - pom.xml
-      - yosql-benchmarks/**
-      - yosql-codegen/**
-      - yosql-examples/**
-      - yosql-internals/**
-      - yosql-models/**
-      - yosql-tooling/**
-  pull_request:
-    branches: [ main ]
-    paths:
-      - .github/workflows/qodana.yml
-      - pom.xml
-      - yosql-benchmarks/**
-      - yosql-codegen/**
-      - yosql-examples/**
-      - yosql-internals/**
-      - yosql-models/**
-      - yosql-tooling/**
+  workflow_dispatch:
 jobs:
   build:
     name: Build


### PR DESCRIPTION
That action seems to be running forever (> 5 hours) since the last update.