### PR TITLE
Update gradle-wrapper to latest version

### DIFF
--- a/yosql-examples/yosql-examples-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/yosql-examples/yosql-examples-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/yosql-tooling/yosql-tooling-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/yosql-tooling/yosql-tooling-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade to latest [gradle version 8.0.2](https://docs.gradle.org/8.0.2/release-notes.html)

<details><summary>fixed issues</summary>

- [#24129](https://github.com/gradle/gradle/issues/24129) includeBuild in PluginManagementSpec deincubated in Gradle 8, docs still say it's incubating
- [#24122](https://github.com/gradle/gradle/issues/24122) Update configuration cache state for some plugins
- [#24109](https://github.com/gradle/gradle/issues/24109) Extending an already resolved configuration no longer works correctly
- [#24031](https://github.com/gradle/gradle/issues/24031) InstrumentingTransformer generates different class files in Gradle 8 and 7.6 which leads to Remote Build-Cache misses
- [#23990](https://github.com/gradle/gradle/issues/23990) Gradle 8.0.+ silently dropped support for custom compilers in `JavaCompile`
- [#23962](https://github.com/gradle/gradle/issues/23962) Java/Scala build with no explicit toolchain: build fails with Gradle 8.0.1 / Scala 2.13
- [#23698](https://github.com/gradle/gradle/issues/23698) Gradle 8 RC2 runs out of metaspace
</details>