### PR TITLE
Update gradle-wrapper to latest version

### DIFF
--- a/yosql-examples/yosql-examples-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/yosql-examples/yosql-examples-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/yosql-tooling/yosql-tooling-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/yosql-tooling/yosql-tooling-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Upgrade to latest [gradle version 8.2.1](https://docs.gradle.org/8.2.1/release-notes.html)

<details><summary>fixed issues</summary>

- [#25674](https://github.com/gradle/gradle/issues/25674) Address regression in dependency graph build operation results
- [#25658](https://github.com/gradle/gradle/issues/25658) Gradle 8.2 sets incorrect value to boolean `--no-feature` option
- [#25618](https://github.com/gradle/gradle/issues/25618) Micronaut JacocoReportAggregationPlugin broken in Gradle 8.2
- [#25611](https://github.com/gradle/gradle/issues/25611) TestKit unexpectedly stopped working with Gradle 2.x versions
- [#25579](https://github.com/gradle/gradle/issues/25579) Regression in 8.2: StackOverflowError w/ Gradle 8.2 + Quarkus 2.16.7 (latest)
</details>