### PR TITLE
Update gradle-wrapper to latest version

### DIFF
--- a/yosql-examples/yosql-examples-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/yosql-examples/yosql-examples-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/yosql-examples/yosql-examples-gradle/gradlew
+++ b/yosql-examples/yosql-examples-gradle/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/yosql-tooling/yosql-tooling-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/yosql-tooling/yosql-tooling-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/yosql-tooling/yosql-tooling-gradle/gradlew
+++ b/yosql-tooling/yosql-tooling-gradle/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \


### PR DESCRIPTION
Upgrade to latest [gradle version 8.4](https://docs.gradle.org/8.4/release-notes.html)

<details><summary>fixed issues</summary>

- [#26298](https://github.com/gradle/gradle/issues/26298) Intermittent NPE in dependency resolution after upgrading to 8.3
- [#26271](https://github.com/gradle/gradle/issues/26271) Closure control flow tracking in dynamic calls interception may leak references to closures throwing exceptions
- [#26258](https://github.com/gradle/gradle/issues/26258) Update configuration cache compatibility matrix to reflect Ear plugin is CC compatible 
- [#26206](https://github.com/gradle/gradle/issues/26206) TestLauncher cannot launch tests from included builds when CC is enabled
- [#26195](https://github.com/gradle/gradle/issues/26195) TestLauncher reports test success even if test fails
- [#26174](https://github.com/gradle/gradle/issues/26174) Beanify `DocLink`
- [#26160](https://github.com/gradle/gradle/issues/26160) Shellcheck shows warnings for the wrapper shell script
- [#26154](https://github.com/gradle/gradle/issues/26154) 8.1 configuration is stuck at 100% for a while when signing is enabled
- [#26147](https://github.com/gradle/gradle/issues/26147) NPE in Gradle annotation processor handling
- [#26139](https://github.com/gradle/gradle/issues/26139) Add explanation for deprecations to dependency management documentation
- [#26093](https://github.com/gradle/gradle/issues/26093) Allow for specifying `--project-cache-dir` in `gradle.properties` file
- [#26087](https://github.com/gradle/gradle/issues/26087) Upgrade embedded Kotlin to 1.9.10
- [#26086](https://github.com/gradle/gradle/issues/26086) --scan option overrides Gradle enterprise plugin version from includedBuild
- [#26085](https://github.com/gradle/gradle/issues/26085) Running tests in :core runs full Groovy recompilation
- [#26056](https://github.com/gradle/gradle/issues/26056) TestLauncher cannot run the same test in different test tasks if configuration cache is enabled
- [#26053](https://github.com/gradle/gradle/issues/26053) Intercepting Groovy dynamic calls stops working in subsequent builds reusing a running daemon
- [#26049](https://github.com/gradle/gradle/issues/26049) Setting org.gradle.unsafe.isolated-projects not causing recalculation of configuration cache
- [#25990](https://github.com/gradle/gradle/issues/25990) Process property upgrades in each subproject separately
- [#25987](https://github.com/gradle/gradle/issues/25987) Auto-discover classes with upgraded properties
- [#25958](https://github.com/gradle/gradle/issues/25958) Comment in Unix wrapper code w.r.t. shell expansion of environment variables is wrong/misleading
- [#25951](https://github.com/gradle/gradle/issues/25951) BuildDashboard causes "Unable to make progress running work" error
- [#25947](https://github.com/gradle/gradle/issues/25947) JUnitJupiterCategoriesOrTagsCoverageIntegrationTest#"can combine tags with custom extension" fails on German OS
- [#25945](https://github.com/gradle/gradle/issues/25945) Upgrade Guava 31.1 -> 32.1.1 for security patches
- [#25943](https://github.com/gradle/gradle/issues/25943) Use of deprecated plexus-cipher plugin results in insecure randomness
- [#25934](https://github.com/gradle/gradle/issues/25934) Gradle 8.3-rc-2 fails with com.gradle.enterprise 3.14.1
- [#25916](https://github.com/gradle/gradle/issues/25916) Print Android Studio logs in the performance tests on sync failure
- [#25908](https://github.com/gradle/gradle/issues/25908) ArtifactView withVariantReselection improperly reselects dependencies with explicit artifacts
- [#25905](https://github.com/gradle/gradle/issues/25905) Daemon client fails while closing connection to the daemon
- [#25894](https://github.com/gradle/gradle/issues/25894) Fix class loading issues for `:test-kit` project with property upgrades
- [#25893](https://github.com/gradle/gradle/issues/25893) Fix class loading of classes that have property upgrades
- [#25877](https://github.com/gradle/gradle/issues/25877) Add missing JUnit4 test cases in R83 TestFailureProgressEventCrossVersionTest
- [#25870](https://github.com/gradle/gradle/issues/25870) Cross compiling windows resources to Windows Arm64 is broken
- [#25863](https://github.com/gradle/gradle/issues/25863) Fix and re-enable persistent compiler daemons on Windows
- [#25859](https://github.com/gradle/gradle/issues/25859) Test filtering in TestNG leads to no tests executing when configuration cache enabled
- [#25857](https://github.com/gradle/gradle/issues/25857) [Gradle + TestNg] Listener initialization failures not logged in the build log/console
- [#25855](https://github.com/gradle/gradle/issues/25855) TestNG Sample tests leaking files with CC enabled
- [#25837](https://github.com/gradle/gradle/issues/25837) Create List, Set and Map live view proxies for upgraded ListProperty, SetProperty and MapProperty
- [#25835](https://github.com/gradle/gradle/issues/25835) PropertyUpgradeClassSourceGenerator should generate `.getOrNull()` calls instead of `.get()`
- [#25834](https://github.com/gradle/gradle/issues/25834) Heap usage regression in 8.3-rc-1
- [#25830](https://github.com/gradle/gradle/issues/25830) FilePermissions has a typo in the default unix value
- [#25828](https://github.com/gradle/gradle/issues/25828) Test suits dependencies block fails when adding a platform defined in Version Catalog
- [#25805](https://github.com/gradle/gradle/issues/25805) Finish release notes and documentation for new configuration factory methods
- [#25798](https://github.com/gradle/gradle/issues/25798) Gradle Conflict Resolution documentation potentially has wrong logic for base version and qualifier parsing
- [#25756](https://github.com/gradle/gradle/issues/25756) Add actionable information to dependency locking error messages 
- [#25742](https://github.com/gradle/gradle/issues/25742) Add deprecation warning to KotlinDslAssignment class
- [#25736](https://github.com/gradle/gradle/issues/25736) Add TAPI support for wrapped assertion failures
- [#25732](https://github.com/gradle/gradle/issues/25732) Handle Property/ConfigurableFileCollection with Groovy in BeanDynamicObject when only getter exists
- [#25651](https://github.com/gradle/gradle/issues/25651) `TaskExecutionGraph#getAllTasks` does not behave as documented
- [#25628](https://github.com/gradle/gradle/issues/25628) DefaultJvmMetadataDetector#getMetadataFromInstallation misses Xmx, so the JVM might allocate significant amount of memory
- [#25612](https://github.com/gradle/gradle/issues/25612) Update TestKit documentation
- [#25604](https://github.com/gradle/gradle/issues/25604) `JvmTestSuites` does not use the `DependencySet` passed to it, causing failures if you have a configuration copy
- [#25573](https://github.com/gradle/gradle/issues/25573) Support compiling and testing with Java 21
- [#25546](https://github.com/gradle/gradle/issues/25546) PMD runs out of Memory running over large source sets in versions 8.1.+
- [#25530](https://github.com/gradle/gradle/issues/25530) Dependency locking fails when lockfile is corrupted
- [#25434](https://github.com/gradle/gradle/issues/25434) Instrumentation of multi-release JARs should not fail on newer versions
- [#25311](https://github.com/gradle/gradle/issues/25311) Test.afterTest is not called with Configuration Cache
- [#25272](https://github.com/gradle/gradle/issues/25272) --no-daemon does not work and returns an unhelpful error message
- [#25044](https://github.com/gradle/gradle/issues/25044) Classpath instrumentation of NIO.2 operations fails for paths in zip archives
- [#24795](https://github.com/gradle/gradle/issues/24795) Upgrade Apache Ivy plugin version to 2.5.1 
- [#24726](https://github.com/gradle/gradle/issues/24726) `CommandLineArgumentProvider` documentation eagerly calls `get()` on provider
- [#24716](https://github.com/gradle/gradle/issues/24716) Intercept getters (and setters) in Groovy closures
- [#24712](https://github.com/gradle/gradle/issues/24712) Support for capturing methods declared in supertypes
- [#24660](https://github.com/gradle/gradle/issues/24660) Add links to sources in Kotlin DSL reference
- [#24613](https://github.com/gradle/gradle/issues/24613) TestNG test listeners not invoked when configuration cache enabled
- [#24575](https://github.com/gradle/gradle/issues/24575) Hanging output rendering after exception during rendering
- [#24508](https://github.com/gradle/gradle/issues/24508) Docs: add 'extra properties' example in 'Migrating build logic from Groovy to Kotlin'
- [#24326](https://github.com/gradle/gradle/issues/24326) ResolvableDependencies#getResolutionResult javadocs are confusing
- [#24314](https://github.com/gradle/gradle/issues/24314) Documentation for setting values in the build environment is confusing
- [#24093](https://github.com/gradle/gradle/issues/24093) Use Kotlin Property assignment in documentation samples
- [#23503](https://github.com/gradle/gradle/issues/23503) Make Kotlin DSL assignment overload a stable feature
- [#23249](https://github.com/gradle/gradle/issues/23249) Don't discard Instrumented listener before storing the work graph
- [#23084](https://github.com/gradle/gradle/issues/23084) Gradle Init w/ incubating features does not place conventions plugins into build-logic when migrating maven projects
- [#23014](https://github.com/gradle/gradle/issues/23014) Configuration caching broken when adding to a MapProperty Task input from a file
- [#22978](https://github.com/gradle/gradle/issues/22978) Documentation icons need label
- [#22968](https://github.com/gradle/gradle/issues/22968) Kotlin DSL generated accessors for JVM types are typed Any, should be typed properly instead
- [#22329](https://github.com/gradle/gradle/issues/22329) How about adding JBR as known java toolchain vendor?
- [#22273](https://github.com/gradle/gradle/issues/22273) Adding the `--scan` option can produce cache misses due to changed order for the `Settings` buildscript classpath
- [#22272](https://github.com/gradle/gradle/issues/22272) Adding the `--scan` option can result in a different version of the GE plugin applied
- [#21796](https://github.com/gradle/gradle/issues/21796) Report deprecation of Provider.forUseAtConfigurationTime()
- [#21676](https://github.com/gradle/gradle/issues/21676) Gradle Daemon Information
- [#21392](https://github.com/gradle/gradle/issues/21392) Update Zinc used by Scala plugin to 1.7.1
- [#19981](https://github.com/gradle/gradle/issues/19981) Provider should have a filter method
- [#18818](https://github.com/gradle/gradle/issues/18818) The file checkstyle-noframes-sorted.xsl is actually LGPL, not Apache 2.0
- [#17489](https://github.com/gradle/gradle/issues/17489) Lacking definition of "project" in docs
- [#16777](https://github.com/gradle/gradle/issues/16777) 7.0: Querying the mapped value ... before task ... has completed is not supported caused by LazyPublishArtifact
- [#14897](https://github.com/gradle/gradle/issues/14897) Gradle should reuse files in jars-8 instead of producing duplicates
- [#12273](https://github.com/gradle/gradle/issues/12273) Documentation to upgrade wrapper is misleading
- [#10771](https://github.com/gradle/gradle/issues/10771) Type information lost on Kotlin DSL accessors to typed Java lambda extensions
- [#10517](https://github.com/gradle/gradle/issues/10517) Unable to use @Option with ListProperty/SetProperty
- [#9834](https://github.com/gradle/gradle/issues/9834) Propose new API to declare different types of 'configurations'
- [#9268](https://github.com/gradle/gradle/issues/9268) Concise and statically-typed `Property<T>` assignment
- [#26672](https://github.com/gradle/gradle/issues/26672) Add workaround hint to upgrade guide for XML failing parser configuration 
- [#26504](https://github.com/gradle/gradle/issues/26504) 8.4-RC1: Release notes: Confusing sample of the configuration api
- [#26465](https://github.com/gradle/gradle/issues/26465) Configuration cache state could not be cached: error writing value of type 'org.gradle.kotlin.dsl.KotlinClosure1' > value.owner must not be null
- [#26359](https://github.com/gradle/gradle/issues/26359) Clarify page title and filter buttons/tabs in the Kotlin DSL reference
- [#26547](https://github.com/gradle/gradle/issues/26547) Restore JvmEcosystemUtilities.registerJvmLanguageSourceDirectory
</details>

<details><summary>known issues</summary>

- [#26678](https://github.com/gradle/gradle/issues/26678) ivy repository URL String parsing broken with 8.3
- [#23208](https://github.com/gradle/gradle/issues/23208) ResolvedArtifact returns incorrect extension for certain artifacts
- [#20330](https://github.com/gradle/gradle/issues/20330) gradle assemble error: "Value for metadata of project :project2 has not been calculated yet"
</details>