### PR TITLE
fix: take the maintained plexus-build-api rather than a stray copy of…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,8 @@
         <version.maven-shared-utils>3.4.2</version.maven-shared-utils>
         <version.mustache>0.9.14</version.mustache>
         <version.picocli>4.7.7</version.picocli>
-        <version.plexus-build-api>0.0.7</version.plexus-build-api>
-        <version.plexus-sec-dispatcher>2.0</version.plexus-sec-dispatcher>
+        <version.plexus-build-api>1.2.0</version.plexus-build-api>
+        <version.plexus-sec-dispatcher>4.1.0</version.plexus-sec-dispatcher>
         <version.postgresql>42.7.13</version.postgresql>
         <version.sisu>0.9.0.M4</version.sisu>
         <version.slf4j>2.0.18</version.slf4j>
@@ -335,7 +335,7 @@
                 <version>${version.slf4j}</version>
             </dependency>
             <dependency>
-                <groupId>org.sonatype.plexus</groupId>
+                <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-build-api</artifactId>
                 <version>${version.plexus-build-api}</version>
             </dependency>

--- a/yosql-tooling/yosql-tooling-maven/pom.xml
+++ b/yosql-tooling/yosql-tooling-maven/pom.xml
@@ -127,14 +127,11 @@
             <artifactId>org.eclipse.sisu.inject</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.plexus</groupId>
+            <!-- Brings its own plexus-utils rather than having it excluded: the mojo needs the
+                 Scanner that BuildContext hands out, and relying on another dependency to drag it
+                 in is how it went missing. -->
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-build-api</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-utils</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/yosql-tooling/yosql-tooling-maven/src/main/java/wtf/metio/yosql/tooling/maven/GenerateMojo.java
+++ b/yosql-tooling/yosql-tooling-maven/src/main/java/wtf/metio/yosql/tooling/maven/GenerateMojo.java
@@ -8,7 +8,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
-import org.sonatype.plexus.build.incremental.BuildContext;
+import org.codehaus.plexus.build.BuildContext;
 import wtf.metio.yosql.codegen.orchestration.YoSQL;
 import wtf.metio.yosql.internals.jdk.SupportedLocales;
 import wtf.metio.yosql.models.immutables.RuntimeConfiguration;


### PR DESCRIPTION
… its dependency

The Maven mojo asks the build context whether its inputs changed, and the class that answers comes from `plexus-utils` — which was excluded from the artifact that needs it, and arrived instead as a transitive of `plexus-sec-dispatcher`. That worked only for as long as nothing moved. Newer `plexus-sec-dispatcher` does not carry it, and the plugin then dies at the point a build first calls it, with a missing class and nothing to say why.

`org.sonatype.plexus:plexus-build-api` has not been released since 2015. Its maintained successor declares `plexus-utils` properly, so the dependency the mojo needs comes from the artifact that needs it. The two versions move together because the old dispatcher is what pinned the older `plexus-utils` on the other path.