### PR TITLE
build: drop the GraalVM SDK nothing compiles against

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ fabric.properties
 
 # htmltest writes its reference cache next to where it is run
 /tmp/
+
+# The throwaway Postgres the native gate starts, when that gate is run locally.
+pgdata/
+pg.log

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
         <version.ant>1.10.17</version.ant>
         <version.cal10n>0.8.1</version.cal10n>
         <version.dagger>2.60.1</version.dagger>
-        <version.graal-sdk>25.2.4</version.graal-sdk>
         <version.h2>2.4.240</version.h2>
         <version.hikaricp>7.1.0</version.hikaricp>
         <version.immutables>2.12.2</version.immutables>
@@ -273,11 +272,6 @@
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>org.eclipse.sisu.plexus</artifactId>
                 <version>${version.sisu}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.graalvm.sdk</groupId>
-                <artifactId>graal-sdk</artifactId>
-                <version>${version.graal-sdk}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.javaparser</groupId>

--- a/yosql-tooling/yosql-tooling-cli/pom.xml
+++ b/yosql-tooling/yosql-tooling-cli/pom.xml
@@ -71,11 +71,6 @@
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.graalvm.sdk</groupId>
-            <artifactId>graal-sdk</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The CLI declared `graal-sdk` as a provided dependency, and no source in the repo imports anything under `org.graalvm`. It is the image builder that needs GraalVM, not the code going into the image, and the builder brings its own — so this only ever gave Renovate something to keep current.