### PR TITLE
chore: take the parent that publishes through the Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>wtf.metio.maven</groupId>
         <artifactId>maven-parent</artifactId>
-        <version>2026.7.24</version>
+        <version>2026.8.1043609</version>
     </parent>
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->


### PR DESCRIPTION
Sonatype replaced the publishing path, and the org-wide parent is where that lives. This one carries `central-publishing-maven-plugin` against server id `central`, which is the id the release workflow already writes credentials for.