### PR TITLE
test: hold the reflection metadata to the model it describes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,9 +66,10 @@ means editing generated output. The website's configuration pages are generated 
 the interface for a deleted configuration group stayed on disk and kept compiling: the build passed
 while a fresh checkout would not have. The generator now deletes what it wrote before writing again,
 and `docs` clears the reference pages while generating rather than only on `mvn clean`, so an
-incremental build sees what CI sees. What still has to be kept in step by hand is the wiring each
-frontend declares per group — `FrontendCoverageTest` fails when a group reaches only some of them —
-and `reflect-config.json`, which lists the model classes a native image needs.
+incremental build sees what CI sees. The two surfaces that are still written by hand — the wiring
+each frontend declares per group, and the `reflect-config.json` listing the model classes a native
+image needs — each have a test that fails when they fall behind the model: `FrontendCoverageTest`
+and `ReflectionMetadataTest`.
 
 ## How generation runs
 
@@ -124,9 +125,11 @@ cd yosql-examples/yosql-examples-gradle && nix develop ../.. --command ./gradlew
 The CLI ships as a native binary. What a closed-world image drops is whatever is reached *by name*
 rather than by call, so `yosql-tooling-cli/src/main/resources/META-INF/native-image/` registers the
 cal10n message bundles behind every diagnostic and the Jackson-bound configuration model. That list
-is enumerated from the compiled classes of `yosql-models-*`; a new model class Jackson needs will not
-be in it, and the failure appears only in the native binary. The native CI job generates real code
-with the binary rather than running `--help`, which is what catches that.
+is enumerated from the compiled classes of `yosql-models-*`, and `ReflectionMetadataTest` compares
+the file against them: a model class Jackson needs and nobody registered, or an entry left behind by
+a class that was deleted, fails there rather than only in the native binary. The native CI job still
+generates real code with the binary rather than running `--help`, because that is what catches the
+reflective lookups no list describes.
 
 ## Conventions
 

--- a/yosql-tooling/yosql-tooling-cli/src/test/java/wtf/metio/yosql/tooling/cli/ReflectionMetadataTest.java
+++ b/yosql-tooling/yosql-tooling-cli/src/test/java/wtf/metio/yosql/tooling/cli/ReflectionMetadataTest.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: The yosql Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package wtf.metio.yosql.tooling.cli;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.zip.ZipFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The reflection metadata has to name exactly the model classes that exist.
+ *
+ * <p>A closed-world image keeps what is reached by call and drops what is reached by name, so the
+ * configuration model Jackson binds is listed here by hand. Both directions of drift are silent:
+ * a class deleted from the model leaves an entry pointing at nothing, and a class added to it is
+ * simply absent — and absent is the one that matters, because the only symptom is a native binary
+ * that cannot read what it was asked to. Neither shows up in any JVM build.</p>
+ *
+ * <p>Which is what happened: the schema configuration shipped without ever being registered, and
+ * eleven entries survived the groups they belonged to. This compares the file against the classes
+ * on the classpath, so the next one fails here rather than in a binary somebody has already
+ * shipped.</p>
+ */
+@DisplayName("native image reflection metadata")
+class ReflectionMetadataTest {
+
+    private static final String CONFIG = "/META-INF/native-image/wtf.metio.yosql.tooling/"
+            + "yosql-tooling-cli/reflect-config.json";
+
+    /**
+     * Jackson binds the configuration model, and nothing else of ours is reached by name.
+     */
+    private static final List<String> REGISTERED_PACKAGES = List.of(
+            "wtf/metio/yosql/models/configuration/",
+            "wtf/metio/yosql/models/immutables/");
+
+    @Test
+    @DisplayName("names every model class, and no class that stopped existing")
+    void shouldMatchTheModelOnTheClasspath() {
+        assertEquals(compiledModelClasses(), registeredClasses(),
+                "reflect-config.json has drifted from the model. Re-derive it from the compiled "
+                        + "classes of yosql-models-configuration and yosql-models-immutables: an entry "
+                        + "too many is dead weight, one too few is a native binary that fails to read "
+                        + "its own configuration.");
+    }
+
+    private static Set<String> registeredClasses() {
+        try (final var source = ReflectionMetadataTest.class.getResourceAsStream(CONFIG)) {
+            final var entries = new ObjectMapper().readTree(source);
+            final var names = new TreeSet<String>();
+            entries.forEach(entry -> names.add(entry.get("name").asText()));
+            return names;
+        } catch (final IOException exception) {
+            throw new UncheckedIOException("Cannot read " + CONFIG, exception);
+        }
+    }
+
+    /**
+     * Reads the classpath rather than scanning with a library: the model modules arrive as
+     * directories inside the reactor and as jars outside it, and both have to answer the same.
+     */
+    private static Set<String> compiledModelClasses() {
+        final var found = new TreeSet<String>();
+        for (final var entry : System.getProperty("java.class.path").split(java.io.File.pathSeparator)) {
+            final var path = Path.of(entry);
+            if (Files.isDirectory(path)) {
+                collectFromDirectory(path, found);
+            } else if (entry.endsWith(".jar")) {
+                collectFromJar(path, found);
+            }
+        }
+        return found;
+    }
+
+    private static void collectFromDirectory(final Path root, final Set<String> found) {
+        try (final var files = Files.walk(root)) {
+            files.filter(Files::isRegularFile)
+                    .map(file -> root.relativize(file).toString().replace(java.io.File.separatorChar, '/'))
+                    .forEach(name -> addWhenModelClass(name, found));
+        } catch (final IOException exception) {
+            throw new UncheckedIOException("Cannot read " + root, exception);
+        }
+    }
+
+    private static void collectFromJar(final Path jar, final Set<String> found) {
+        try (final var archive = new ZipFile(jar.toFile())) {
+            archive.stream().map(java.util.zip.ZipEntry::getName).forEach(name -> addWhenModelClass(name, found));
+        } catch (final IOException _) {
+            // A classpath entry that is not a readable archive says nothing about the model.
+        }
+    }
+
+    private static void addWhenModelClass(final String name, final Set<String> found) {
+        if (!name.endsWith(".class") || name.endsWith("package-info.class")) {
+            return;
+        }
+        if (REGISTERED_PACKAGES.stream().noneMatch(name::startsWith)) {
+            return;
+        }
+        found.add(name.substring(0, name.length() - ".class".length()).replace('/', '.'));
+    }
+
+}


### PR DESCRIPTION
A closed-world image keeps what is reached by call and drops what is reached by name, so the Jackson-bound configuration model is listed by hand. Both directions of drift are silent: a class deleted from the model leaves an entry pointing at nothing, and a class added to it is simply absent — and absent is the one that matters, because the symptom is a native binary that cannot read its own configuration. Neither shows up in any JVM build.

Which is what happened this release. The schema configuration shipped without ever being registered, and eleven entries outlived the groups they belonged to.

The file is now compared against the model classes on the classpath, read from the classpath itself rather than through a scanning library: the model modules arrive as directories inside the reactor and as jars outside it, and both have to answer the same. Deriving the list instead would have meant guessing which of `$Builder`, `$InitShim` and `$Json` the annotation processor emits for a given group, which is guesswork that works until it does not.