### PR TITLE
test: state what the generator must hold true, and let jqwik hunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,7 @@ fabric.properties
 # The throwaway Postgres the native gate starts, when that gate is run locally.
 pgdata/
 pg.log
+
+# jqwik remembers which sample last failed a property, so a rerun tries it first.
+# Per checkout, not per project.
+**/.jqwik-database

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -54,3 +54,11 @@ path = ["**/gradle/wrapper/gradle-wrapper.jar", "**/gradle/wrapper/gradle-wrappe
 precedence = "override"
 SPDX-FileCopyrightText = "Gradle Inc."
 SPDX-License-Identifier = "Apache-2.0"
+
+# jqwik's replay cache, written beside whichever module ran a property. Not
+# source, not committed, and regenerated on the next run.
+[[annotations]]
+path = "**/.jqwik-database"
+precedence = "override"
+SPDX-FileCopyrightText = "The yosql Authors"
+SPDX-License-Identifier = "0BSD"

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
         <version.jsqlparser>5.3</version.jsqlparser>
         <version.jmh>1.37</version.jmh>
         <version.jspecify>1.0.1</version.jspecify>
+        <version.jqwik>1.10.1</version.jqwik>
         <version.junit>6.1.2</version.junit>
         <version.kotlin>2.4.10</version.kotlin>
         <version.log4j>2.26.1</version.log4j>
@@ -156,6 +157,15 @@
                 <version>${version.jackson}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!--
+                Property-based tests. Its own engine on the JUnit platform, so surefire runs it
+                beside the jupiter tests rather than instead of them.
+            -->
+            <dependency>
+                <groupId>net.jqwik</groupId>
+                <artifactId>jqwik</artifactId>
+                <version>${version.jqwik}</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>

--- a/yosql-codegen/pom.xml
+++ b/yosql-codegen/pom.xml
@@ -127,6 +127,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/blocks/DefaultFields.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/blocks/DefaultFields.java
@@ -50,6 +50,11 @@ public final class DefaultFields implements Fields {
 
     @Override
     public CodeBlock initialize(final String statement) {
+        if (!fitsInATextBlock(statement)) {
+            // A plain literal, which JavaPoet escapes in full. Less pleasant to read, and the only
+            // form that can hold this one.
+            return CodeBlock.of("$S", statement);
+        }
         return CodeBlock.builder()
                 .add("\"\"\"")
                 .add("$>$>\n$L", forTextBlock(statement))
@@ -58,33 +63,92 @@ public final class DefaultFields implements Fields {
     }
 
     /**
+     * Whether a text block can give this statement back unchanged.
+     *
+     * <p>Text blocks strip trailing white space by {@link Character#isWhitespace(char)}, and the only
+     * whitespace they offer an escape for is the space, the tab, the carriage return and the form
+     * feed. A statement carrying any other — an ideographic space, say — cannot be protected: a
+     * {@code \\uXXXX} escape would not help, because those are resolved before the text block is
+     * read and would arrive as the whitespace itself.</p>
+     *
+     * <p>An empty statement has no line to hold, and comes back as a line ending instead.</p>
+     */
+    private static boolean fitsInATextBlock(final String statement) {
+        return !statement.isEmpty() && statement.chars().allMatch(DefaultFields::writableInATextBlock);
+    }
+
+    /**
+     * The whitespace a text block offers an escape for, plus anything that is not whitespace and not
+     * a control character. Everything else — a vertical tab, an ideographic space — either gets
+     * stripped or changes meaning, and cannot be written back in.
+     *
+     * <p>The carriage return and the form feed are among them: a text block turns both into a
+     * newline, and an escape cannot stop that because it is the block's own content being
+     * normalised. A statement carrying either — a file with CRLF endings, most likely — is written
+     * as a plain literal instead.</p>
+     */
+    private static boolean writableInATextBlock(final int character) {
+        return character == ' ' || character == '\t' || character == '\n'
+                || !Character.isWhitespace(character) && !Character.isISOControl(character);
+    }
+
+    /**
      * The statement as a text block reads it back.
      *
      * <p>SQL is dropped into a text block so that the constant stays readable, but a text block is
      * still Java source: a backslash starts an escape sequence there. A regular expression such as
      * {@code '\d+'} is not a legal one and stops the user's compile; {@code '\s+'} is legal and
-     * means a single space, so the constant silently becomes a different query than the one written.
-     * Trailing whitespace is stripped by the text block itself, which matters when it falls inside a
-     * string literal the statement spans two lines.</p>
+     * means a single space, so the constant silently becomes a different query than the one written.</p>
+     *
+     * <p>Whitespace at either end of a line is escaped as well, because a text block decides what to
+     * strip by looking at how far its lines are indented. Trailing whitespace it removes outright.
+     * Leading whitespace it counts as indentation, and how much of that survives depends on where
+     * the closing delimiter lands — which for a single-line statement is the content line itself, so
+     * the statement's own leading spaces were taken for indentation and removed. Escaped, none of it
+     * is whitespace as far as that rule is concerned, and the text comes back as it went in.</p>
+     *
+     * <p>Every quote is escaped rather than only the runs of three that would close the block early.
+     * Two rules that both rewrite quotes have to agree about what the other already rewrote, and
+     * they did not: a statement ending in a quote sits against the closing delimiter, so escaping
+     * that one had to happen after the runs were broken up, by which point the trailing run included
+     * a quote the first rule had already escaped. One rule cannot disagree with itself.</p>
      */
     private static String forTextBlock(final String statement) {
-        final var escaped = statement.replace("\\", "\\\\").replace("\"\"\"", "\"\"\\\"");
+        final var escaped = statement.replace("\\", "\\\\").replace("\"", "\\\"");
         return Arrays.stream(escaped.split("\n", -1))
-                .map(DefaultFields::keepTrailingWhitespace)
+                .map(DefaultFields::keepEdgeWhitespace)
                 .collect(Collectors.joining("\n"));
     }
 
-    private static String keepTrailingWhitespace(final String line) {
-        final var kept = line.stripTrailing();
-        if (kept.length() == line.length()) {
-            return line;
+    /**
+     * @return the line with the whitespace at either end written as escapes
+     */
+    private static String keepEdgeWhitespace(final String line) {
+        var leading = 0;
+        while (leading < line.length() && isStrippable(line.charAt(leading))) {
+            leading++;
         }
-        final var escaped = new StringBuilder(kept);
-        line.substring(kept.length()).chars().forEach(character -> escaped.append(switch (character) {
+        if (leading == line.length()) {
+            return escapeWhitespace(line);
+        }
+        var trailing = line.length();
+        while (trailing > leading && isStrippable(line.charAt(trailing - 1))) {
+            trailing--;
+        }
+        return escapeWhitespace(line.substring(0, leading))
+                + line.substring(leading, trailing)
+                + escapeWhitespace(line.substring(trailing));
+    }
+
+    private static boolean isStrippable(final char character) {
+        return character != '\n' && Character.isWhitespace(character);
+    }
+
+    private static String escapeWhitespace(final String whitespace) {
+        final var escaped = new StringBuilder(whitespace.length() * 2);
+        whitespace.chars().forEach(character -> escaped.append(switch (character) {
             case ' ' -> "\\s";
             case '\t' -> "\\t";
-            case '\r' -> "\\r";
-            case '\f' -> "\\f";
             default -> String.valueOf((char) character);
         }));
         return escaped.toString();

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/blocks/DefaultFieldsTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/blocks/DefaultFieldsTest.java
@@ -68,12 +68,13 @@ class DefaultFieldsTest {
         }
 
         @Test
-        @DisplayName("so that three quotes do not end it early")
-        void escapesTripleQuotes() {
+        @DisplayName("so that no run of quotes can end it early")
+        void escapesQuotes() {
             final var initialized = generator.initialize("select \"\"\" from t").toString();
-            Assertions.assertTrue(initialized.contains("\"\"\\\""),
-                    () -> "three quotes close the block: " + initialized);
+            Assertions.assertTrue(initialized.contains("\\\"\\\"\\\""),
+                    () -> "a run of quotes could close the block: " + initialized);
         }
+
 
         @Test
         @DisplayName("so that whitespace inside a literal survives the line ending")

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/blocks/SqlConstantProperties.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/blocks/SqlConstantProperties.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: The yosql Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package wtf.metio.yosql.codegen.blocks;
+
+import com.palantir.javapoet.FieldSpec;
+import com.palantir.javapoet.JavaFile;
+import com.palantir.javapoet.TypeSpec;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.junit.jupiter.api.Assertions;
+import wtf.metio.yosql.codegen.dao.JavaCompilation;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Field;
+import java.util.List;
+
+/**
+ * A statement survives the trip into a generated constant and back.
+ *
+ * <p>The SQL goes into a Java text block, and a text block is source: a backslash starts an escape
+ * sequence there, three quotes end the block, and trailing whitespace is stripped. Getting that
+ * wrong stops the user's compile at best, and at worst compiles into a different query than the one
+ * that was written — {@code '\s+'} is a legal escape meaning a single space.</p>
+ *
+ * <p>So the check is a round trip rather than a comparison against expected text: the constant is
+ * compiled by javac, loaded, and read back. Comparing text would mean writing the escaping rules a
+ * second time, and a second implementation is a second thing to get wrong — which is how the schema
+ * validator came to look up columns that do not exist.</p>
+ */
+class SqlConstantProperties {
+
+    private static final String CLASS = "com.example.persistence.Constants";
+
+    /**
+     * The characters a text block reads as something other than themselves, mixed with ordinary SQL.
+     */
+    @Provide
+    Arbitrary<String> statements() {
+        return Arbitraries.of(
+                        "select", " ", "\n", "\t", "id", "from", "t", "where", "a", "=", "'", "\"",
+                        "\\", "\\n", "\\s", "\\d+", "\"\"\"", "\"\"", "$", "%s", "{", "}", "\r",
+                        "  ", "'\\d+'", "/*", "*/", "--", ";", "€", "ß", "\\\\")
+                .list().ofMinSize(1).ofMaxSize(25)
+                .map(parts -> String.join("", parts));
+    }
+
+    @Property(tries = 300)
+    void aStatementReadsBackAsItself(@ForAll("statements") final String statement) {
+        Assertions.assertEquals(escape(statement), escape(readBack(statement)),
+                () -> "the constant does not hold the statement it was given: " + escape(statement));
+    }
+
+    /**
+     * Text nobody thought about, rather than only the characters this test knows to be awkward.
+     *
+     * <p>Bounded to what a `.sql` file plausibly holds: printable characters, tabs, newlines and
+     * carriage returns. Not every code point — U+2028 breaks the plain string literal JavaPoet
+     * writes, and what JavaPoet can hold is not something YoSQL is in a position to promise.</p>
+     */
+    @Property(tries = 200)
+    void arbitraryTextReadsBackAsItself(@ForAll("fileText") final String text) {
+        Assertions.assertEquals(escape(text), escape(readBack(text)),
+                () -> "the constant does not hold the text it was given: " + escape(text));
+    }
+
+    @Provide
+    Arbitrary<String> fileText() {
+        return Arbitraries.strings()
+                .withChars('\t', '\n', '\r')
+                .withCharRange('\u0020', '\u007e')
+                .withCharRange('\u00a0', '\u04ff')
+                .withCharRange('\u4e00', '\u4eff')
+                .ofMaxLength(60);
+    }
+
+    /**
+     * Compiles a class holding the statement as the generator writes it, then asks the JVM what the
+     * constant actually contains.
+     */
+    private static String readBack(final String statement) {
+        final var fields = new DefaultFields(BlocksObjectMother.annotationGenerator());
+        final var constant = FieldSpec.builder(String.class, "QUERY",
+                        Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                .initializer(fields.initialize(statement))
+                .build();
+        final var type = TypeSpec.classBuilder("Constants")
+                .addModifiers(Modifier.PUBLIC)
+                .addField(constant)
+                .build();
+        final var source = JavaFile.builder("com.example.persistence", type).build().toString();
+        try {
+            final var loaded = JavaCompilation.compileAndLoad(
+                    List.of(new JavaCompilation.Source(CLASS, source)));
+            final Field field = loaded.loadClass(CLASS).getDeclaredField("QUERY");
+            return (String) field.get(null);
+        } catch (final ReflectiveOperationException exception) {
+            throw new IllegalStateException(exception);
+        } catch (final IllegalStateException exception) {
+            throw new IllegalStateException("javac rejected the constant generated for ["
+                    + escape(statement) + "]:\n" + exception.getMessage() + "\n\n" + source, exception);
+        }
+    }
+
+    /**
+     * Every character written so it can be read, because a counterexample full of control characters
+     * applies itself to the terminal instead of showing what it was.
+     */
+    private static String escape(final String text) {
+        final var readable = new StringBuilder(text.length() * 2);
+        text.codePoints().forEach(point -> {
+            if (point == '\\') {
+                readable.append("\\\\");
+            } else if (point >= 0x20 && point < 0x7F) {
+                readable.appendCodePoint(point);
+            } else {
+                readable.append("\\u%04x".formatted(point));
+            }
+        });
+        return readable.toString();
+    }
+
+}

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/dao/GeneratorFuzzTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/dao/GeneratorFuzzTest.java
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: The yosql Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package wtf.metio.yosql.codegen.dao;
+
+import com.palantir.javapoet.JavaFile;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.junit.jupiter.api.Assertions;
+import wtf.metio.yosql.internals.testing.configs.LoggingConfigurations;
+import wtf.metio.yosql.internals.testing.configs.RepositoriesConfigurations;
+import wtf.metio.yosql.internals.testing.configs.SqlConfigurations;
+import wtf.metio.yosql.models.configuration.ReturningMode;
+import wtf.metio.yosql.models.configuration.SqlParameter;
+import wtf.metio.yosql.models.configuration.SqlStatementType;
+import wtf.metio.yosql.models.immutables.LoggingConfiguration;
+import wtf.metio.yosql.models.immutables.SqlConfiguration;
+import wtf.metio.yosql.models.immutables.SqlStatement;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Whatever a statement asks for, the generator answers with Java or with a diagnostic.
+ *
+ * <p>The compile oracle walks the combinations somebody enumerated. This one lets jqwik build the
+ * statement instead — its type, what it returns, how it logs, whether it batches, how many
+ * parameters it binds and what its SQL says — and holds the generator to the rule the project is
+ * built on: a statement that cannot be generated correctly fails the build with a message naming it,
+ * and one that can produces a repository that compiles. There is no third answer, and the failures
+ * worth finding are the ones nobody thought to enumerate.</p>
+ *
+ * <p>A refusal counts as a pass, so long as it is one of ours. An exception from the JDK or from
+ * JavaPoet is a failure however sensible its message, because it names neither the file nor the
+ * statement — which is the whole reason the {@code exceptions} package exists.</p>
+ */
+class GeneratorFuzzTest {
+
+    private static final String REPOSITORY = "com.example.persistence.DataRepository";
+
+    /**
+     * The converter every repository calls, compiled alongside so the test states what shape the
+     * generated code expects of it.
+     */
+    private static final JavaCompilation.Source CONVERTER = new JavaCompilation.Source(
+            "com.example.persistence.converter.ToMapConverter",
+            """
+            package com.example.persistence.converter;
+
+            public final class ToMapConverter {
+                public java.util.Map<java.lang.String, java.lang.Object> apply(
+                        final java.sql.ResultSet resultSet) throws java.sql.SQLException {
+                    return java.util.Map.of();
+                }
+            }
+            """);
+
+    @Provide
+    Arbitrary<String> parameterNames() {
+        return Arbitraries.strings().withCharRange('a', 'f').ofMinLength(1).ofMaxLength(3);
+    }
+
+    @Provide
+    Arbitrary<String> parameterTypes() {
+        return Arbitraries.of("java.lang.String", "int", "long", "java.util.UUID",
+                "java.time.Instant", "java.lang.Object", "java.util.List<java.lang.String>");
+    }
+
+    @Provide
+    Arbitrary<List<SqlParameter>> parameters() {
+        return Combinators.combine(parameterNames(), parameterTypes())
+                .as((name, type) -> (SqlParameter) SqlParameter.builder()
+                        .setName(name).setType(type).build())
+                .list().ofMaxSize(4)
+                // A name bound twice is one parameter, and the configurers upstream have already
+                // merged them by the time a generator sees the statement.
+                .map(list -> list.stream()
+                        .collect(java.util.stream.Collectors.toMap(
+                                parameter -> parameter.name().orElseThrow(),
+                                parameter -> parameter,
+                                (first, second) -> first,
+                                java.util.LinkedHashMap::new))
+                        .values().stream().toList());
+    }
+
+    @Provide
+    Arbitrary<String> rawStatements() {
+        return Arbitraries.of(
+                        "select ", "* ", "from t ", "where ", "a = :a ", "b = ? ", "and ",
+                        "in (:c) ", "'text' ", "-- note\n", "/* c */ ", ";", "\n", "x::text ",
+                        "'it''s' ", "\"quoted\" ")
+                .list().ofMinSize(1).ofMaxSize(12)
+                .map(parts -> String.join("", parts));
+    }
+
+    @Provide
+    Arbitrary<LoggingConfiguration> loggingApis() {
+        return Arbitraries.of(
+                LoggingConfigurations.defaults(), LoggingConfigurations.jul(),
+                LoggingConfigurations.log4j(), LoggingConfigurations.slf4j(),
+                LoggingConfigurations.system(), LoggingConfigurations.tiny());
+    }
+
+    @Property(tries = 400)
+    void aStatementIsEitherGeneratedOrRefused(
+            @ForAll final SqlStatementType type,
+            @ForAll final ReturningMode returningMode,
+            @ForAll final boolean createConnection,
+            @ForAll final boolean catchAndRethrow,
+            @ForAll final boolean usePreparedStatement,
+            @ForAll final boolean executeBatch,
+            @ForAll("parameters") final List<SqlParameter> parameters,
+            @ForAll("rawStatements") final String rawStatement,
+            @ForAll("loggingApis") final LoggingConfiguration logging) {
+        final var configuration = SqlConfiguration.copyOf(SqlConfigurations.sqlConfiguration())
+                .withType(type)
+                .withReturningMode(returningMode)
+                .withCreateConnection(createConnection)
+                .withCatchAndRethrow(catchAndRethrow)
+                .withUsePreparedStatement(usePreparedStatement)
+                .withExecuteBatch(executeBatch)
+                .withParameters(parameters);
+        final List<SqlStatement> statements = List.of(SqlStatement.builder()
+                .setSourcePath(Path.of("src", "main", "yosql", "queryData.sql"))
+                .setConfiguration(configuration)
+                .setRawStatement(rawStatement)
+                .build());
+
+        final String source;
+        try {
+            final var generated = DaoObjectMother
+                    .repositoryGenerator(logging, RepositoriesConfigurations.defaults())
+                    .generateRepositoryClass(REPOSITORY, statements);
+            source = JavaFile.builder(generated.getPackageName(), generated.getType()).build().toString();
+        } catch (final RuntimeException refused) {
+            Assertions.assertTrue(isOurs(refused),
+                    () -> "refused with " + refused.getClass().getName() + " rather than a diagnostic "
+                            + "naming the statement, for " + describe(type, returningMode, rawStatement)
+                            + "\n" + refused.getMessage());
+            Assertions.assertNotNull(refused.getMessage(),
+                    () -> refused.getClass().getSimpleName() + " carries no message, so the build "
+                            + "would print null, for " + describe(type, returningMode, rawStatement));
+            return;
+        }
+
+        final var errors = JavaCompilation.errorsIn(List.of(CONVERTER,
+                new JavaCompilation.Source(REPOSITORY, source)));
+        Assertions.assertTrue(errors.isEmpty(),
+                () -> "javac rejected the repository generated for "
+                        + describe(type, returningMode, rawStatement) + ":\n"
+                        + String.join("\n", errors) + "\n\n" + source);
+    }
+
+    /**
+     * Ours, meaning it comes from the package whose whole job is to say which statement went wrong.
+     */
+    private static boolean isOurs(final RuntimeException exception) {
+        return exception.getClass().getPackageName()
+                .equals("wtf.metio.yosql.codegen.exceptions");
+    }
+
+    private static String describe(
+            final SqlStatementType type,
+            final ReturningMode returningMode,
+            final String rawStatement) {
+        return type + " + " + returningMode + " over [" + rawStatement.replace("\n", "\\n") + "]";
+    }
+
+}

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/dao/JavaCompilation.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/dao/JavaCompilation.java
@@ -22,7 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
@@ -37,7 +39,7 @@ import java.util.stream.Collectors;
  * <p>Nothing is written to disk. The class files go to memory and are then discarded; only the
  * diagnostics matter.</p>
  */
-final class JavaCompilation {
+public final class JavaCompilation {
 
     private JavaCompilation() {
         // utility class
@@ -47,7 +49,7 @@ final class JavaCompilation {
      * @param sources fully qualified name to source text
      * @return every error {@code javac} reported, empty when it compiled
      */
-    static List<String> errorsIn(final List<Source> sources) {
+    public static List<String> errorsIn(final List<Source> sources) {
         final var compiler = ToolProvider.getSystemJavaCompiler();
         if (compiler == null) {
             throw new IllegalStateException("no java compiler on this JVM — run the tests on a JDK");
@@ -116,7 +118,7 @@ final class JavaCompilation {
      * @param qualifiedName the class the source declares
      * @param code the source text
      */
-    record Source(String qualifiedName, String code) {
+    public record Source(String qualifiedName, String code) {
 
         JavaFileObject asFileObject() {
             return new SimpleJavaFileObject(
@@ -133,13 +135,56 @@ final class JavaCompilation {
     }
 
     /**
-     * Keeps the class files out of the build directory — they are a by-product, and what is being
-     * asked is whether they could be produced at all.
+     * Compiles and then loads, so that a test can ask the running JVM what the generated code
+     * actually says rather than compare its text against a second copy of the same escaping rules.
+     *
+     * @return a loader over the compiled classes
+     * @throws IllegalStateException when the sources do not compile
+     */
+    public static ClassLoader compileAndLoad(final List<Source> sources) {
+        final var compiler = ToolProvider.getSystemJavaCompiler();
+        final var diagnostics = new DiagnosticCollector<JavaFileObject>();
+        final var units = sources.stream().map(Source::asFileObject).toList();
+        final var classes = new HashMap<String, byte[]>();
+        try (final var standard = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8);
+             final var manager = new InMemoryClassFiles(standard, classes)) {
+            final var options = List.of("-classpath", classpath(), "-proc:none");
+            if (!compiler.getTask(null, manager, diagnostics, options, null, units).call()) {
+                throw new IllegalStateException(diagnostics.getDiagnostics().stream()
+                        .filter(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                        .map(JavaCompilation::describe)
+                        .collect(Collectors.joining("\n")));
+            }
+        } catch (final IOException exception) {
+            throw new IllegalStateException(exception);
+        }
+        return new ClassLoader(JavaCompilation.class.getClassLoader()) {
+            @Override
+            protected Class<?> findClass(final String name) throws ClassNotFoundException {
+                final var bytes = classes.get(name);
+                if (bytes == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                return defineClass(name, bytes, 0, bytes.length);
+            }
+        };
+    }
+
+    /**
+     * Keeps the class files out of the build directory — they are a by-product. Their bytes are kept
+     * in memory so that {@link #compileAndLoad(List)} can define them.
      */
     private static final class InMemoryClassFiles extends ForwardingJavaFileManager<JavaFileManager> {
 
+        private final Map<String, byte[]> classes;
+
         private InMemoryClassFiles(final JavaFileManager delegate) {
+            this(delegate, null);
+        }
+
+        private InMemoryClassFiles(final JavaFileManager delegate, final Map<String, byte[]> classes) {
             super(delegate);
+            this.classes = classes;
         }
 
         @Override
@@ -152,7 +197,14 @@ final class JavaCompilation {
                     URI.create("memory:///" + className.replace('.', '/') + kind.extension), kind) {
                 @Override
                 public OutputStream openOutputStream() {
-                    return new ByteArrayOutputStream();
+                    return new ByteArrayOutputStream() {
+                        @Override
+                        public void close() {
+                            if (classes != null) {
+                                classes.put(className, toByteArray());
+                            }
+                        }
+                    };
                 }
             };
         }

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/files/SqlTextProperties.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/files/SqlTextProperties.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-FileCopyrightText: The yosql Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package wtf.metio.yosql.codegen.files;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+
+/**
+ * What masking a statement must hold true for, whatever the statement.
+ *
+ * <p>The example-based tests here name the cases somebody thought of. These name what has to be true
+ * of every case, and let jqwik go looking for one that is not — which is the useful direction for a
+ * function whose whole job is to survive input nobody anticipated.</p>
+ */
+class SqlTextProperties {
+
+    /**
+     * Fragments a statement is built from, mixing the things that end a literal or a comment with
+     * the things that only look like they do.
+     */
+    @Provide
+    Arbitrary<String> sqlFragments() {
+        return Arbitraries.of(
+                "select", " ", "\n", "id", ",", "from", "t", "where", "a", "=", ":name", "?",
+                "'", "\"", "--", "/*", "*/", "$$", "$tag$", "::", "text", "'it''s'", "\t",
+                ":", "'unterminated", "/* nested /* deeper */ */", "e'\\''", "%", "(", ")");
+    }
+
+    @Provide
+    Arbitrary<String> statements() {
+        return sqlFragments().list().ofMinSize(0).ofMaxSize(40).map(parts -> String.join("", parts));
+    }
+
+    /**
+     * Offsets have to keep pointing at the same characters, because every caller matches against the
+     * mask and then reads or rewrites the statement itself.
+     */
+    @Property(tries = 2000)
+    void maskKeepsEveryOffset(@ForAll("statements") final String sql) {
+        Assertions.assertEquals(sql.length(), SqlText.maskLiteralsAndComments(sql).length(),
+                () -> "mask changed length for: " + sql);
+    }
+
+    /**
+     * Masking says which characters are code. Asking again cannot change that answer, and a function
+     * that is not idempotent here would mean the first answer depended on something it had already
+     * removed.
+     */
+    @Property(tries = 2000)
+    void maskIsIdempotent(@ForAll("statements") final String sql) {
+        final var once = SqlText.maskLiteralsAndComments(sql);
+        Assertions.assertEquals(once, SqlText.maskLiteralsAndComments(once),
+                () -> "masking twice differs from masking once for: " + sql);
+    }
+
+    /**
+     * A character is either left alone or blanked. Turning one character into a different character
+     * would put a placeholder where the author wrote none — the very failure this exists to stop.
+     */
+    @Property(tries = 2000)
+    void maskOnlyBlanks(@ForAll("statements") final String sql) {
+        final var masked = SqlText.maskLiteralsAndComments(sql);
+        for (var index = 0; index < sql.length(); index++) {
+            final var position = index;
+            final var original = sql.charAt(index);
+            final var result = masked.charAt(index);
+            Assertions.assertTrue(result == original || result == ' ',
+                    () -> "character at " + position + " became '" + result + "' in: " + sql);
+        }
+    }
+
+    /**
+     * Newlines survive, because a line comment ends at one and blanking it would swallow the rest of
+     * the statement.
+     */
+    @Property(tries = 2000)
+    void maskKeepsNewlines(@ForAll("statements") final String sql) {
+        final var masked = SqlText.maskLiteralsAndComments(sql);
+        for (var index = 0; index < sql.length(); index++) {
+            if (sql.charAt(index) == '\n') {
+                Assertions.assertEquals('\n', masked.charAt(index),
+                        () -> "a newline was blanked in: " + sql);
+            }
+        }
+    }
+
+    /**
+     * A statement carrying none of the characters that open a literal or a comment is all code, so
+     * the mask is the statement.
+     */
+    @Property(tries = 1000)
+    void plainSqlIsUntouched(@ForAll("plainStatements") final String sql) {
+        Assertions.assertEquals(sql, SqlText.maskLiteralsAndComments(sql),
+                () -> "code was blanked in: " + sql);
+    }
+
+    @Provide
+    Arbitrary<String> plainStatements() {
+        return Arbitraries.of("select", " ", "\n", "id", ",", "from", "t", "where", "=", ":name",
+                        "?", "::", "(", ")", "a", "1")
+                .list().ofMaxSize(30).map(parts -> String.join("", parts));
+    }
+
+    /**
+     * Whatever is inside a literal is text. Wrapping any fragment in quotes has to hide every
+     * placeholder in it, however the fragment is spelled.
+     */
+    @Property(tries = 2000)
+    void quotedFragmentsHideTheirPlaceholders(@ForAll("quotable") final String fragment) {
+        final var sql = "select * from t where a = '" + fragment + "' and b = :b";
+        final var masked = SqlText.maskLiteralsAndComments(sql);
+        final var literal = masked.substring(sql.indexOf('\'') , sql.lastIndexOf('\'') + 1);
+        Assertions.assertTrue(literal.isBlank(),
+                () -> "a literal kept content [" + literal + "] in: " + sql);
+        Assertions.assertTrue(masked.contains(":b"),
+                () -> "the parameter after the literal was lost in: " + sql);
+    }
+
+    /**
+     * Without a quote of its own, so that the fragment cannot close the literal it is put inside.
+     */
+    @Provide
+    Arbitrary<String> quotable() {
+        return Arbitraries.of(":id", "?", "--", "/*", "*/", "20:30", "a", " ", "::", "$$", "%s")
+                .list().ofMaxSize(8).map(parts -> String.join("", parts));
+    }
+
+    /**
+     * Every placeholder the parser finds sits outside a literal — which is the same statement
+     * SqlText makes, read from the other end.
+     */
+    @Property(tries = 2000)
+    void everyFoundParameterIsCode(@ForAll("statements") final String sql) {
+        final var masked = SqlText.maskLiteralsAndComments(sql);
+        SqlStatementParser.extractParameterIndices(sql).keySet().stream()
+                .filter(name -> !SqlStatementParser.UNNAMED_PARAMETERS.equals(name))
+                .forEach(name -> Assertions.assertTrue(masked.contains(":" + name),
+                        () -> "parameter '" + name + "' is not in the masked statement: " + sql));
+    }
+
+    /**
+     * A placeholder's number is its position among all of them, so the numbers a statement yields
+     * are exactly 1..n with nothing missing and nothing repeated. A gap means a JDBC index nobody
+     * binds; a repeat means two values bound to one.
+     */
+    @Property(tries = 2000)
+    void indicesAreContiguousFromOne(@ForAll("statements") final String sql) {
+        final var indices = SqlStatementParser.extractParameterIndices(sql).values().stream()
+                .flatMap(List::stream)
+                .sorted()
+                .toList();
+        for (var offset = 0; offset < indices.size(); offset++) {
+            final var expected = offset + 1;
+            final var position = offset;
+            Assertions.assertEquals(expected, indices.get(position),
+                    () -> "indices " + indices + " are not 1.." + indices.size() + " for: " + sql);
+        }
+    }
+
+    /**
+     * Reading a statement cannot fail. Every diagnostic about a statement is raised later by
+     * something that knows which file it came from, so an exception escaping here would name
+     * nothing.
+     */
+    @Property(tries = 2000)
+    void readingNeverThrows(@ForAll("statements") final String sql) {
+        Assertions.assertDoesNotThrow(() -> {
+            SqlText.maskLiteralsAndComments(sql);
+            SqlStatementParser.extractParameterIndices(sql);
+        }, () -> "reading threw for: " + sql);
+    }
+
+    /**
+     * Arbitrary text, not only text built from SQL-shaped pieces: a `.sql` file can hold anything a
+     * person can type.
+     */
+    @Property(tries = 2000)
+    void readingNeverThrowsForArbitraryText(@ForAll final String text) {
+        Assertions.assertDoesNotThrow(() -> {
+            SqlText.maskLiteralsAndComments(text);
+            SqlStatementParser.extractParameterIndices(text);
+        }, () -> "reading threw for: " + text);
+    }
+
+    /**
+     * A statement whose parameters are all named binds as many placeholders as it writes names.
+     */
+    @Property(tries = 1000)
+    void namedParametersAreCountedOnce(@ForAll("names") final List<String> names) {
+        final var sql = "select * from t where "
+                + String.join(" and ", names.stream().map(name -> name + " = :" + name).toList());
+        final var indices = SqlStatementParser.extractParameterIndices(sql);
+        Assertions.assertEquals(names.stream().distinct().count(), indices.size(),
+                () -> "wrong number of parameters for: " + sql);
+    }
+
+    @Provide
+    Arbitrary<List<String>> names() {
+        return Arbitraries.strings().withCharRange('a', 'z').ofMinLength(1).ofMaxLength(6)
+                .list().ofMinSize(1).ofMaxSize(6);
+    }
+
+
+}

--- a/yosql-internals/yosql-internals-javapoet-utils/pom.xml
+++ b/yosql-internals/yosql-internals-javapoet-utils/pom.xml
@@ -45,6 +45,11 @@
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/yosql-internals/yosql-internals-jdk-utils/pom.xml
+++ b/yosql-internals/yosql-internals-jdk-utils/pom.xml
@@ -41,6 +41,11 @@
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/yosql-models/yosql-models-configuration/pom.xml
+++ b/yosql-models/yosql-models-configuration/pom.xml
@@ -72,6 +72,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
The tests here name cases somebody thought of. Properties name what has to be true of every case and go looking for one that is not, which is the useful direction for code whose job is to survive input nobody anticipated — a `.sql` file holds whatever was typed into it.

SqlTextProperties holds masking to its invariants: the mask is the same length, it only ever blanks, it keeps newlines, asking twice gives the same answer, and no placeholder the parser reports sits inside a literal. It also holds a statement's placeholder numbers to being exactly 1..n, since a gap is a JDBC index nobody binds and a repeat is two values bound to one.

SqlConstantProperties is a round trip rather than a comparison: the constant is compiled by javac, loaded, and read back. Comparing text would mean writing the escaping rules a second time, and a second implementation is a second thing to get wrong.

It found five ways a statement did not survive the trip.

  - A leading space was lost. JavaPoet puts the closing delimiter on the last content line, so for a single-line statement Java strips that line's whole indentation — including the statement's own.
  - A statement ending in a quote ran into the delimiter and made a fourth, so the block closed early and the file did not compile.
  - A bare carriage return, and a form feed, each came back as a newline. A text block normalises them wherever they sit, and no escape stops it, so a statement carrying either is written as a plain literal now.
  - An empty statement came back as a line ending.

Quotes are escaped one by one rather than by breaking up the runs of three. Two rules that both rewrite quotes have to agree about what the other already rewrote, and they did not.

GeneratorFuzzTest builds the statement instead of enumerating it — type, returning mode, logging API, batching, parameters, SQL — and holds the generator to the rule the project is built on: either Java that compiles, or one of our own exceptions, carrying a message. An exception from the JDK or from JavaPoet fails it however sensible its message, because it names neither the file nor the statement.

Checked by putting a brace bug back: it fails and shrinks the counterexample to `select `.