### PR TITLE
fix: also refuse a generated type the project already declares

### DIFF
--- a/docs/content/installation/upgrading.md
+++ b/docs/content/installation/upgrading.md
@@ -127,10 +127,30 @@ Two generated types would both be written as 'com.example.persistence.Document':
 and a record.
 ```
 
-This only affects a build that was already failing at compile time, so nothing that worked can start
-failing. If you see it, rename whichever of the two names is yours — usually the `resultRowType`,
-into a package of its own — or turn off
+The same name can also meet a class you wrote yourself, which is the likelier of the two: a project
+keeping its stores in the repositories' package has hand-written classes sitting exactly where the
+generator writes, and a `windDown` statements directory generates an interface called `WindDown`.
+That was a duplicate class from `javac`, in whichever of the two files it reached first. It is now
+the same kind of failure, before anything is written, naming the file it met.
+
+Either way this only affects a build that was already failing at compile time, so nothing that
+worked can start failing. If you see it, rename whichever of the two names is yours, move it to
+another package, or turn off
 [generateInterfaces](/configuration/repositories/generateinterfaces/).
+
+### The build says which columns it cannot type
+
+Alongside the table count, a run now names the columns the schema holds and cannot give a Java type:
+
+```text
+The schema holds 1 column(s) whose type YoSQL does not map: document.payload (jsonb). No vendor
+is declared, and the types only one database has are looked up only for a declared one — so
+'schema.vendor' may be all that is missing.
+```
+
+The table count is the same whether or not a vendor is declared — it is the columns that change —
+so it was the wrong figure to read a vendor's effect off. This is the one that answers it. Nothing
+to do: an untyped column that no statement selects and no parameter is named after costs nothing.
 
 ## 2026.8.8
 

--- a/docs/content/sql/schema.md
+++ b/docs/content/sql/schema.md
@@ -184,6 +184,18 @@ and `longtext` — resolve only once something declares the vendor. Until then t
 described but untyped: parameters naming them need their type written out, and
 `generateResultRowType` will not write the record.
 
+A run says which columns that leaves untyped, so the question does not have to be guessed at:
+
+```text
+The schema holds 1 column(s) whose type YoSQL does not map: document.payload (jsonb). No vendor
+is declared, and the types only one database has are looked up only for a declared one — so
+'schema.vendor' may be all that is missing.
+```
+
+The table count above it is the same either way — it is the columns that change — so it is the
+wrong figure to read a vendor's effect off. An untyped column that no statement selects and no
+parameter is named after costs nothing, which is why this is said rather than warned about.
+
 Mark the DDL itself, once per file, and every statement reading it follows:
 
 ```sql

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/exceptions/GeneratedTypeExistsException.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/exceptions/GeneratedTypeExistsException.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: The yosql Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+package wtf.metio.yosql.codegen.exceptions;
+
+import java.io.Serial;
+import java.nio.file.Path;
+
+/**
+ * Signals that a type about to be generated is a type the project already has.
+ *
+ * <p>Separate from {@link DuplicateGeneratedTypeException} because the advice differs and so does
+ * the fix: nothing here can be resolved by renaming something else that was generated, and the file
+ * that already exists is one the reader wrote and may not want moved.</p>
+ */
+public final class GeneratedTypeExistsException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public GeneratedTypeExistsException(final String type, final String kind, final Path existing) {
+        super(("YoSQL would generate %s '%s', and %s already declares that type. Two files claiming "
+                + "one name is a duplicate class, reported by the compiler in whichever of them it "
+                + "reaches first — often the generated one, which names neither this file nor the "
+                + "setting that chose the name. A repository interface is the repository's name "
+                + "without its 'Repository' suffix, so statements in a 'windDown' directory generate "
+                + "an interface called 'WindDown'. Rename one of the two, move yours to another "
+                + "package, or turn off 'repositories.generateInterfaces'.")
+                .formatted(kind, type, existing));
+    }
+
+}

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/orchestration/DefaultYoSQL.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/orchestration/DefaultYoSQL.java
@@ -5,8 +5,6 @@
 package wtf.metio.yosql.codegen.orchestration;
 
 import ch.qos.cal10n.IMessageConveyor;
-import com.palantir.javapoet.TypeSpec;
-import wtf.metio.yosql.codegen.exceptions.DuplicateGeneratedTypeException;
 import wtf.metio.yosql.codegen.dao.CodeGenerator;
 import wtf.metio.yosql.codegen.files.FileParser;
 import wtf.metio.yosql.codegen.lifecycle.*;
@@ -15,8 +13,6 @@ import wtf.metio.yosql.models.immutables.PackagedTypeSpec;
 import wtf.metio.yosql.codegen.schema.SchemaValidator;
 import wtf.metio.yosql.models.immutables.SqlStatement;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;
@@ -40,6 +36,7 @@ public final class DefaultYoSQL implements YoSQL {
     private final ExecutionErrors errors;
     private final RuntimeValidator validator;
     private final SchemaValidator schemaValidator;
+    private final GeneratedTypeCollisions collisions;
 
     public DefaultYoSQL(
             final FileParser fileParser,
@@ -50,7 +47,8 @@ public final class DefaultYoSQL implements YoSQL {
             final TypeWriter typeWriter,
             final ExecutionErrors errors,
             final RuntimeValidator validator,
-            final SchemaValidator schemaValidator) {
+            final SchemaValidator schemaValidator,
+            final GeneratedTypeCollisions collisions) {
         this.fileParser = fileParser;
         this.codeGenerator = codeGenerator;
         this.pool = pool;
@@ -60,6 +58,7 @@ public final class DefaultYoSQL implements YoSQL {
         this.errors = errors;
         this.validator = validator;
         this.schemaValidator = schemaValidator;
+        this.collisions = collisions;
     }
 
     @Override
@@ -115,43 +114,8 @@ public final class DefaultYoSQL implements YoSQL {
     private Stream<PackagedTypeSpec> generateCode(final List<SqlStatement> statements) {
         final var generated = timer.timed(messages.getMessage(CodegenLifecycle.GENERATE_REPOSITORIES),
                 () -> codeGenerator.generateCode(statements).toList());
-        rejectDuplicates(generated);
+        collisions.reject(generated);
         return generated.stream();
-    }
-
-    /**
-     * Two generated types that would be written as the same file.
-     *
-     * <p>Here rather than in any one generator, because no generator can see it: a repository
-     * interface, a record and a converter are named by rules that never meet, and each name is
-     * unobjectionable on its own. This is the only place the whole set exists at once, and it is
-     * before anything is on disk.</p>
-     */
-    private static void rejectDuplicates(final List<PackagedTypeSpec> generated) {
-        final var byName = new LinkedHashMap<String, List<PackagedTypeSpec>>();
-        generated.forEach(spec -> byName.computeIfAbsent(
-                spec.getPackageName() + "." + spec.getType().name(),
-                key -> new ArrayList<>()).add(spec));
-        for (final var entry : byName.entrySet()) {
-            if (entry.getValue().size() > 1) {
-                throw new DuplicateGeneratedTypeException(entry.getKey(), entry.getValue().stream()
-                        .map(spec -> describe(spec.getType().kind()))
-                        .toList());
-            }
-        }
-    }
-
-    /**
-     * JavaPoet spells its kinds in capitals, which reads as shouting in the middle of a sentence.
-     */
-    private static String describe(final TypeSpec.Kind kind) {
-        return switch (kind) {
-            case INTERFACE -> "an interface";
-            case RECORD -> "a record";
-            case ENUM -> "an enum";
-            case ANNOTATION -> "an annotation";
-            case CLASS -> "a class";
-        };
     }
 
     private void writeIntoFiles(final Stream<PackagedTypeSpec> typeSpecs) {

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/orchestration/GeneratedTypeCollisions.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/orchestration/GeneratedTypeCollisions.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: The yosql Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+package wtf.metio.yosql.codegen.orchestration;
+
+import com.palantir.javapoet.ClassName;
+import com.palantir.javapoet.TypeSpec;
+import wtf.metio.yosql.codegen.exceptions.DuplicateGeneratedTypeException;
+import wtf.metio.yosql.codegen.exceptions.GeneratedTypeExistsException;
+import wtf.metio.yosql.codegen.records.RecordScanner;
+import wtf.metio.yosql.models.immutables.PackagedTypeSpec;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Two types that would end up as one file.
+ *
+ * <p>Every generated type is one file, named after itself, and the names that can meet are settled
+ * by rules that never see each other: a repository interface is the repository's name without its
+ * suffix, a generated record is whatever {@code resultRowType} says, a converter is a prefix and a
+ * suffix around a record's name — and a class somebody wrote by hand is subject to no rule at all.
+ * Nothing about any one of those names is wrong on its own, which is why no generator can catch
+ * this and why it is caught here, where the whole set exists at once and nothing is on disk yet.</p>
+ *
+ * <p>Both directions matter. Two generated types agreeing is one file written twice, whichever runs
+ * second surviving. A generated type agreeing with a file the project already has is two files
+ * claiming one name, which {@code javac} reports as a duplicate class in whichever of them it
+ * reaches first — pointing at neither the statement nor the setting that chose the name.</p>
+ */
+public final class GeneratedTypeCollisions {
+
+    /**
+     * What our own output says about itself.
+     *
+     * <p>A project is free to point {@code sourceDirectory} at somewhere that already holds
+     * generated code — the output of an earlier run, or a module that keeps both together. Finding
+     * our own answer there and calling it a collision would fail a build for existing, which is
+     * exactly the file this run is about to replace.</p>
+     */
+    private static final String OUR_OWN = "\"wtf.metio.yosql\"";
+
+    private final RecordScanner scanner;
+
+    public GeneratedTypeCollisions(final RecordScanner scanner) {
+        this.scanner = scanner;
+    }
+
+    public void reject(final List<PackagedTypeSpec> generated) {
+        rejectAgainstEachOther(generated);
+        rejectAgainstExistingSources(generated);
+    }
+
+    private static void rejectAgainstEachOther(final List<PackagedTypeSpec> generated) {
+        final var byName = new LinkedHashMap<String, List<PackagedTypeSpec>>();
+        generated.forEach(spec -> byName.computeIfAbsent(nameOf(spec), key -> new ArrayList<>()).add(spec));
+        for (final var entry : byName.entrySet()) {
+            if (entry.getValue().size() > 1) {
+                throw new DuplicateGeneratedTypeException(entry.getKey(), entry.getValue().stream()
+                        .map(spec -> describe(spec.getType().kind()))
+                        .toList());
+            }
+        }
+    }
+
+    private void rejectAgainstExistingSources(final List<PackagedTypeSpec> generated) {
+        for (final var spec : generated) {
+            final var existing = scanner.locationOf(ClassName.bestGuess(nameOf(spec)));
+            if (Files.isRegularFile(existing) && !isOurOwn(existing)) {
+                throw new GeneratedTypeExistsException(nameOf(spec),
+                        describe(spec.getType().kind()), existing);
+            }
+        }
+    }
+
+    private static boolean isOurOwn(final java.nio.file.Path source) {
+        try {
+            return Files.readString(source, StandardCharsets.UTF_8).contains(OUR_OWN);
+        } catch (final IOException _) {
+            // Unreadable says nothing either way, and a build should not fail over a file it cannot
+            // open to answer a question about a name.
+            return true;
+        }
+    }
+
+    private static String nameOf(final PackagedTypeSpec spec) {
+        return spec.getPackageName() + "." + spec.getType().name();
+    }
+
+    /**
+     * JavaPoet spells its kinds in capitals, which reads as shouting in the middle of a sentence.
+     */
+    private static String describe(final TypeSpec.Kind kind) {
+        return switch (kind) {
+            case INTERFACE -> "an interface";
+            case RECORD -> "a record";
+            case ENUM -> "an enum";
+            case ANNOTATION -> "an annotation";
+            case CLASS -> "a class";
+        };
+    }
+
+}

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/schema/SchemaValidator.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/schema/SchemaValidator.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Optional;
+import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -61,6 +62,7 @@ public final class SchemaValidator {
             return;
         }
         logger.info(schemaSummary());
+        untypedColumns().ifPresent(logger::info);
         if (schemas.isEmpty()) {
             return;
         }
@@ -90,6 +92,45 @@ public final class SchemaValidator {
                     + "or keep your 'create table' statements among the SQL files YoSQL already reads.";
         }
         return "The schema reads %d table(s): %s.".formatted(tables.size(), String.join(", ", tables));
+    }
+
+    /**
+     * Which columns the schema holds and cannot say the Java type of.
+     *
+     * <p>The table count answers whether the DDL arrived; it cannot answer whether the columns in it
+     * mean anything, and the two get read as one thing. A vendor's own spellings resolve only for a
+     * declared vendor, so a schema can be complete, counted, and still type nothing — and the only
+     * sign of it downstream is a parameter that has to be declared by hand, which reads as YoSQL
+     * simply not inferring much.</p>
+     *
+     * <p>Said at {@code INFO} rather than warned about, because a column nobody selects and nobody
+     * names a parameter after is untyped without costing anything. What makes it worth printing is
+     * that it is the difference between "declaring the vendor would change nothing" and "declaring
+     * the vendor is the thing that has been missing", and nothing else distinguishes them.</p>
+     */
+    // visible for testing
+    Optional<String> untypedColumns() {
+        final var untyped = new TreeSet<String>();
+        for (final var catalog : schemas.applicableTo(Optional.empty())) {
+            final var dialect = catalog.dialect(Optional.empty());
+            for (final var tableName : catalog.tableNames()) {
+                catalog.table(tableName).ifPresent(table -> table.columnNames().forEach(columnName ->
+                        table.column(columnName)
+                                .filter(column -> SqlTypes.javaType(column, dialect).isEmpty())
+                                .ifPresent(column -> untyped.add("%s.%s (%s)"
+                                        .formatted(table.name(), column.name(), column.sqlType())))));
+            }
+        }
+        if (untyped.isEmpty()) {
+            return Optional.empty();
+        }
+        final var vendor = schemas.applicableTo(Optional.empty()).stream()
+                .anyMatch(catalog -> catalog.dialect(Optional.empty()).isPresent())
+                ? ""
+                : " No vendor is declared, and the types only one database has are looked up only "
+                        + "for a declared one — so 'schema.vendor' may be all that is missing.";
+        return Optional.of("The schema holds %d column(s) whose type YoSQL does not map: %s.%s"
+                .formatted(untyped.size(), String.join(", ", untyped), vendor));
     }
 
     /**

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/orchestration/DuplicateGeneratedTypesTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/orchestration/DuplicateGeneratedTypesTest.java
@@ -125,7 +125,10 @@ final class DuplicateGeneratedTypesTest {
                         new RecordScanner(
                                 FilesConfiguration.builder().setSourceDirectory(sources).build(),
                                 new JavaSourceParser()),
-                        LoggingObjectMother.logger()));
+                        LoggingObjectMother.logger()),
+                new GeneratedTypeCollisions(new RecordScanner(
+                        FilesConfiguration.builder().setSourceDirectory(sources).build(),
+                        new JavaSourceParser())));
     }
 
     private static TypeWriter recording(final List<String> written) {

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/orchestration/GeneratedTypeCollisionsTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/orchestration/GeneratedTypeCollisionsTest.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-FileCopyrightText: The yosql Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package wtf.metio.yosql.codegen.orchestration;
+
+import com.palantir.javapoet.TypeSpec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import wtf.metio.yosql.codegen.exceptions.DuplicateGeneratedTypeException;
+import wtf.metio.yosql.codegen.exceptions.GeneratedTypeExistsException;
+import wtf.metio.yosql.codegen.records.JavaSourceParser;
+import wtf.metio.yosql.codegen.records.RecordScanner;
+import wtf.metio.yosql.models.immutables.FilesConfiguration;
+import wtf.metio.yosql.models.immutables.PackagedTypeSpec;
+
+import javax.lang.model.element.Modifier;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two types that would end up as one file, from either direction.
+ *
+ * <p>A repository interface is the repository's name without its {@code Repository} suffix, so
+ * statements in a {@code windDown} directory generate an interface called {@code WindDown}. That
+ * name can meet a second generated type, and it can meet a class the project already has — and the
+ * second is the ordinary shape, because a project whose stores live in the repositories' package
+ * has hand-written classes sitting exactly where the generator writes.</p>
+ */
+@DisplayName("a generated type that is not the only one with its name")
+final class GeneratedTypeCollisionsTest {
+
+    private static final String PACKAGE = "com.example.store";
+
+    @TempDir
+    Path sources;
+
+    private GeneratedTypeCollisions collisions() {
+        return new GeneratedTypeCollisions(new RecordScanner(
+                FilesConfiguration.builder().setSourceDirectory(sources).build(),
+                new JavaSourceParser()));
+    }
+
+    private static PackagedTypeSpec anInterface(final String name) {
+        return PackagedTypeSpec.of(
+                TypeSpec.interfaceBuilder(name).addModifiers(Modifier.PUBLIC).build(), PACKAGE);
+    }
+
+    private static PackagedTypeSpec aRecord(final String name) {
+        return PackagedTypeSpec.of(
+                TypeSpec.recordBuilder(name).addModifiers(Modifier.PUBLIC).build(), PACKAGE);
+    }
+
+    private void existingSource(final String name, final String body) throws IOException {
+        final var directory = sources.resolve(PACKAGE.replace('.', '/'));
+        Files.createDirectories(directory);
+        Files.writeString(directory.resolve(name + ".java"), body, StandardCharsets.UTF_8);
+    }
+
+    @Nested
+    @DisplayName("against another generated type")
+    class AgainstGenerated {
+
+        @Test
+        @DisplayName("names both kinds")
+        void shouldRefuseTwoGeneratedTypes() {
+            final var thrown = assertThrows(DuplicateGeneratedTypeException.class, () ->
+                    collisions().reject(List.of(anInterface("Document"), aRecord("Document"))));
+
+            assertAll(
+                    () -> assertTrue(thrown.getMessage().contains("com.example.store.Document"),
+                            thrown.getMessage()),
+                    () -> assertTrue(thrown.getMessage().contains("an interface and a record"),
+                            thrown.getMessage()));
+        }
+
+        @Test
+        @DisplayName("is content with one of each name")
+        void shouldAllowDistinctNames() {
+            assertDoesNotThrow(() ->
+                    collisions().reject(List.of(anInterface("Document"), aRecord("Payload"))));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("against a class the project already has")
+    class AgainstExistingSource {
+
+        @Test
+        @DisplayName("names the file it would have collided with")
+        void shouldRefuseAHandWrittenClass() throws IOException {
+            // What a project hits with generateInterfaces on and its stores in the repositories'
+            // package: generation succeeded, and javac reported a duplicate class in a generated
+            // file, naming neither the statements directory nor the class it met.
+            existingSource("WindDown", """
+                    package com.example.store;
+
+                    public final class WindDown {
+                    }
+                    """);
+
+            final var thrown = assertThrows(GeneratedTypeExistsException.class, () ->
+                    collisions().reject(List.of(anInterface("WindDown"))));
+
+            assertAll(
+                    () -> assertTrue(thrown.getMessage().contains("com.example.store.WindDown"),
+                            thrown.getMessage()),
+                    () -> assertTrue(thrown.getMessage().contains("WindDown.java"),
+                            thrown.getMessage()),
+                    () -> assertTrue(thrown.getMessage().contains("generateInterfaces"),
+                            thrown.getMessage()));
+        }
+
+        @Test
+        @DisplayName("says nothing about a class of another name")
+        void shouldAllowUnrelatedSources() throws IOException {
+            existingSource("WindDown", """
+                    package com.example.store;
+
+                    public final class WindDown {
+                    }
+                    """);
+
+            assertDoesNotThrow(() -> collisions().reject(List.of(anInterface("Document"))));
+        }
+
+        @Test
+        @DisplayName("passes over an answer of its own from an earlier run")
+        void shouldIgnoreItsOwnOutput() throws IOException {
+            // A project is free to point sourceDirectory at somewhere holding generated code. What
+            // is there is the file this run is about to replace, and failing for its existence would
+            // make the second build of an unchanged project fail.
+            existingSource("Document", """
+                    package com.example.store;
+
+                    @javax.annotation.processing.Generated(
+                        value = "wtf.metio.yosql",
+                        comments = "generated by YoSQL - do not modify"
+                    )
+                    public interface Document {
+                    }
+                    """);
+
+            assertDoesNotThrow(() -> collisions().reject(List.of(anInterface("Document"))));
+        }
+
+    }
+
+}

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/orchestration/GenerationPrecedesWritingTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/orchestration/GenerationPrecedesWritingTest.java
@@ -69,7 +69,10 @@ final class GenerationPrecedesWritingTest {
                         new RecordScanner(
                                 FilesConfiguration.builder().setSourceDirectory(sources).build(),
                                 new JavaSourceParser()),
-                        LoggingObjectMother.logger()));
+                        LoggingObjectMother.logger()),
+                new GeneratedTypeCollisions(new RecordScanner(
+                        FilesConfiguration.builder().setSourceDirectory(sources).build(),
+                        new JavaSourceParser())));
 
         yosql.generateCode();
 

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/schema/SchemaValidatorTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/schema/SchemaValidatorTest.java
@@ -463,6 +463,44 @@ class SchemaValidatorTest {
                     () -> assertTrue(summary.contains("sqlStatementsDirectory"), summary));
         }
 
+        @Test
+        @DisplayName("names the columns whose type it cannot say, and what may be missing")
+        void shouldSayWhichColumnsAreUntyped() {
+            final var untyped = validator(SchemaValidation.ERROR,
+                    "create table document (id uuid not null primary key, payload jsonb not null)")
+                    .untypedColumns().orElseThrow();
+
+            assertAll(
+                    () -> assertTrue(untyped.contains("1 column(s)"), untyped),
+                    () -> assertTrue(untyped.contains("document.payload (jsonb)"), untyped),
+                    () -> assertTrue(untyped.contains("schema.vendor"), untyped));
+        }
+
+        @Test
+        @DisplayName("says nothing when every column has a type")
+        void shouldSayNothingWhenEverythingIsTyped() {
+            assertEquals(Optional.empty(),
+                    validator(SchemaValidation.ERROR, TENANT_DDL).untypedColumns());
+        }
+
+        /**
+         * The table count is the same either way — it is the columns that change — so the count is
+         * the wrong figure to read a vendor's effect off, and this is the right one.
+         */
+        @Test
+        @DisplayName("stops mentioning the vendor once the DDL declares one")
+        void shouldNotSuggestAVendorItAlreadyHas() {
+            final var validator = new SchemaValidator(
+                    Schemas.of(List.of(new VendorStatement(Optional.of("PostgreSQL"),
+                            "create table document (id uuid not null primary key, payload jsonb not null)"))),
+                    SchemaConfiguration.builder().setValidation(SchemaValidation.ERROR).build(),
+                    new RecordScanner(FilesConfiguration.builder().setSourceDirectory(sources).build(),
+                            new JavaSourceParser()),
+                    LoggingObjectMother.logger());
+
+            assertEquals(Optional.empty(), validator.untypedColumns());
+        }
+
     }
 
 }

--- a/yosql-tooling/yosql-tooling-dagger/src/main/java/wtf/metio/yosql/tooling/dagger/orchestration/DefaultOrchestrationModule.java
+++ b/yosql-tooling/yosql-tooling-dagger/src/main/java/wtf/metio/yosql/tooling/dagger/orchestration/DefaultOrchestrationModule.java
@@ -11,6 +11,7 @@ import dagger.Provides;
 import org.slf4j.cal10n.LocLogger;
 import wtf.metio.yosql.codegen.dao.CodeGenerator;
 import wtf.metio.yosql.codegen.files.FileParser;
+import wtf.metio.yosql.codegen.records.RecordScanner;
 import wtf.metio.yosql.codegen.schema.SchemaValidator;
 import wtf.metio.yosql.codegen.orchestration.*;
 import wtf.metio.yosql.codegen.validation.RuntimeValidator;
@@ -37,7 +38,8 @@ public class DefaultOrchestrationModule {
             final TypeWriter typeWriter,
             final ExecutionErrors errors,
             final RuntimeValidator runtimeValidator,
-            final SchemaValidator schemaValidator) {
+            final SchemaValidator schemaValidator,
+            final GeneratedTypeCollisions collisions) {
         return new DefaultYoSQL(
                 files,
                 codeGenerator,
@@ -47,7 +49,14 @@ public class DefaultOrchestrationModule {
                 typeWriter,
                 errors,
                 runtimeValidator,
-                schemaValidator);
+                schemaValidator,
+                collisions);
+    }
+
+    @Provides
+    @Singleton
+    GeneratedTypeCollisions provideGeneratedTypeCollisions(final RecordScanner scanner) {
+        return new GeneratedTypeCollisions(scanner);
     }
 
     @Provides


### PR DESCRIPTION
The guard added last week only compared generated types with each other, which misses the likelier half. A project keeping its stores in the repositories' package has hand-written classes sitting exactly where the generator writes, and a `windDown` statements directory generates an interface called `WindDown`: generation succeeded, and javac reported a duplicate class, naming neither the directory nor the class it met.

The check moves out of the orchestration into a collaborator that asks both questions, because the second needs somewhere to look — the source directory the record scanner already reads. A file carrying our own Generated marker is passed over, so pointing sourceDirectory at somewhere holding an earlier run's output still builds; that is the file this run is about to replace.

Alongside it, a run now names the columns the schema holds and cannot type. The table count is identical whether or not a vendor is declared — it is the columns that change — so it was the wrong figure to read a vendor's effect off, and there was no right one.