### PR TITLE
fix: say that a parameter's name is what its type is inferred from

### DIFF
--- a/.claude/skills/yosql/SKILL.md
+++ b/.claude/skills/yosql/SKILL.md
@@ -105,6 +105,13 @@ A parameter names its column the way a record component does: `:accountId` reads
 `:account_id` reads it too. `uuid`, `varchar` and `timestamp` columns give `UUID`, `String` and
 `Instant`; a nullable column gives the boxed type.
 
+**The parameter's name is the whole input.** Nothing about the comparison it appears in is used, so
+`insert into tenant (id, slug) values (:id, :slug)` infers both and
+`select slug from tenant where id = :tenantId` infers nothing — the column is `id`. Rename the
+parameter after its column, or declare the type and keep the name where it says more than the column
+would. A table reached only inside a subquery is not one of the statement's tables, and a statement
+selecting from a derived table or a CTE has no scope to match against at all.
+
 Four sources, in this order, and the first that answers wins:
 
 1. the `parameters` block — always authoritative, whatever the schema says;

--- a/docs/content/sql/schema.md
+++ b/docs/content/sql/schema.md
@@ -135,6 +135,38 @@ the parameter can be null; a `not null` column gives the primitive.
 What you write always wins. Naming a type in the front matter is how you use a type of your own —
 a `TenantId` wrapping a `UUID` — and how you settle anything this gets wrong.
 
+### What "named after" means
+
+The parameter's own name, matched against the columns of the tables the statement reads. Nothing
+about the comparison it appears in is used, so this infers every parameter:
+
+```sql
+insert into tenant_invitation (id, tenant_id, email, invited_at)
+values (:id, :tenantId, :email, :invitedAt)
+```
+
+and this infers none of its one:
+
+```sql
+select currency from tenant where id = :tenantId
+```
+
+The column is `id`, the parameter is `tenantId`, and the statement is otherwise as simple as it
+gets. Rename the parameter after its column, or declare the type — a parameter named for what it
+means rather than for its column is worth keeping and declaring. `staleBefore` in
+`last_seen_at < :staleBefore` says more than `lastSeenAt` would, and it needs a type.
+
+Two boundaries follow from "the tables the statement reads":
+
+- A table reached only inside a subquery is not one of them, so `:tenantId` in
+  `order_id in (select id from placed_order where tenant_id = :tenantId)` has nothing to match. The
+  statement's own parameters are unaffected.
+- A statement selecting from a derived table or a common table expression has no scope that can be
+  listed at all, and none of its parameters are inferred.
+
+The build says which of these it is when it cannot type a parameter, including the columns it
+matched against.
+
 ## Records come free too
 
 A result row type is usually a record whose components repeat, one by one, what the `select` list

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/exceptions/UntypedParameterException.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/exceptions/UntypedParameterException.java
@@ -22,22 +22,31 @@ public final class UntypedParameterException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     /**
-     * @param tablesRead the tables the schema came out holding, for the case this most often is: the
-     *                   schema was read, and the table this statement needs is not in it
+     * @param tablesRead     the tables the schema came out holding, for the case this most often is:
+     *                       the schema was read, and the table this statement needs is not in it
+     * @param tablesInScope  the tables this statement reads from, or {@code null} when it reads from
+     *                       something that cannot be enumerated — a subquery, a common table
+     *                       expression, a function call
+     * @param columnsInScope the columns those tables hold, which are the names a parameter can be
+     *                       inferred from
      */
     public UntypedParameterException(
             final Path source,
             final String statement,
             final Collection<String> parameters,
-            final Collection<String> tablesRead) {
-        super(message(source, statement, parameters, tablesRead));
+            final Collection<String> tablesRead,
+            final Collection<String> tablesInScope,
+            final Collection<String> columnsInScope) {
+        super(message(source, statement, parameters, tablesRead, tablesInScope, columnsInScope));
     }
 
     private static String message(
             final Path source,
             final String statement,
             final Collection<String> parameters,
-            final Collection<String> tablesRead) {
+            final Collection<String> tablesRead,
+            final Collection<String> tablesInScope,
+            final Collection<String> columnsInScope) {
         final var message = new StringBuilder("Statement '%s' in %s binds %s no type is known for: "
                 .formatted(statement, source, parameters.size() == 1 ? "a parameter" : "parameters"));
         message.append(String.join(", ", parameters)).append('.');
@@ -48,19 +57,47 @@ public final class UntypedParameterException extends RuntimeException {
         message.append("names such as 'uuid', 'string' or 'instant'.");
         message.append("\n  A statement naming a record with 'resultRowType' takes the type of the ");
         message.append("component of the same name, so a parameter matching one needs nothing here.");
+        // The input is the parameter's *name*, and nothing said so. A message that lists what the
+        // schema holds and never mentions the name reads as "the schema is short", which sends a
+        // reader to their migrations and their vendor setting — both of them fine — while the
+        // statement in front of them compares ':tenantId' against a column called 'id'.
+        message.append("\n\n  A parameter takes its type from a column of the same name in the ");
+        message.append("tables this statement reads, 'camelCase' read as 'snake_case'. ");
+        if (tablesInScope == null) {
+            message.append("This statement reads from something that cannot be listed — a subquery, ");
+            message.append("a common table expression or a function call — so no column of it is ");
+            message.append("matched against, and every parameter here needs its type named.");
+        } else if (columnsInScope.isEmpty()) {
+            message.append("It reads from ").append(String.join(", ", tablesInScope));
+            message.append(", and the schema describes no columns of those with a type, so there is ");
+            message.append("nothing to match against.");
+        } else {
+            message.append("It reads ").append(String.join(", ", tablesInScope));
+            message.append(", holding: ").append(String.join(", ", columnsInScope)).append(".");
+            message.append("\n  Rename the parameter after the column it means, or name its type ");
+            message.append("above — a name that says more than the column does is a good reason to ");
+            message.append("keep it and declare the type.");
+        }
         // What the schema came out holding, because the answer is so often "the table this needs is
         // not in it". A schema is checked silently — a statement reading a table nobody described is
         // skipped rather than failed — so this is the first place a reader learns the catalog is
         // short, and reading it as "name the type" sends them to fix the wrong thing.
-        message.append("\n\n  The schema read ").append(tablesRead.size()).append(" table(s)");
-        if (tablesRead.isEmpty()) {
-            message.append(", so nothing could be inferred from it. Check that 'schema."
-                    + "sqlStatementsDirectory' points at your DDL, or keep your 'create table' "
-                    + "statements among the SQL files YoSQL already reads.");
-        } else {
-            message.append(": ").append(String.join(", ", tablesRead))
-                    .append(".\n  A parameter named after a column of a table that is not in that list "
-                            + "has nothing to be inferred from.");
+        //
+        // Only where it can still explain something. Once the columns above are listed, the reader
+        // has seen what was matched against and what the parameter is called; repeating what the
+        // schema holds after that points back at a schema that is not the problem, which is the way
+        // this message has misled before.
+        if (columnsInScope.isEmpty()) {
+            message.append("\n\n  The schema read ").append(tablesRead.size()).append(" table(s)");
+            if (tablesRead.isEmpty()) {
+                message.append(", so nothing could be inferred from it. Check that 'schema."
+                        + "sqlStatementsDirectory' points at your DDL, or keep your 'create table' "
+                        + "statements among the SQL files YoSQL already reads.");
+            } else {
+                message.append(": ").append(String.join(", ", tablesRead))
+                        .append(".\n  A parameter named after a column of a table that is not in that "
+                                + "list has nothing to be inferred from.");
+            }
         }
         return message.toString();
     }

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurer.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurer.java
@@ -157,8 +157,10 @@ public final class DefaultMethodParameterConfigurer implements MethodParameterCo
             }
         }
         if (!untyped.isEmpty()) {
+            final var scope = TableScope.of(sql);
             throw new UntypedParameterException(source, configuration.name().orElse("<unnamed>"), untyped,
-                    tablesRead(configuration.vendor()));
+                    tablesRead(configuration.vendor()), scope.exhaustive() ? scope.tables() : null,
+                    columns.keySet());
         }
         return typed;
     }

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurerTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurerTest.java
@@ -317,6 +317,78 @@ class DefaultMethodParameterConfigurerTest {
                     () -> assertEquals("java.lang.String", configured.parameters().get(1).type().orElseThrow()));
         }
 
+        @Nested
+        @DisplayName("and when it cannot, says what it matched against")
+        class WhenItCannot {
+
+            private static final String TENANT = """
+                    create table tenant (
+                        id       uuid not null primary key,
+                        currency varchar(3) not null
+                    )""";
+
+            @Test
+            @DisplayName("states the rule and lists the columns the statement reads")
+            void shouldSayTheNameIsTheInput() {
+                // The column is 'id' and the parameter is 'tenantId'. Everything else is in order —
+                // the table is described, the type is one we map, the comparison is a bare equality
+                // — so a message about what the schema holds reads as "the schema is short" and
+                // sends the reader to their migrations.
+                final var exception = assertThrows(UntypedParameterException.class,
+                        () -> withSchema(TENANT).configureParameters(statement(), SOURCE,
+                                "select currency from tenant where id = :tenantId",
+                                indices("tenantId")));
+
+                assertAll(
+                        () -> assertTrue(exception.getMessage().contains("column of the same name"),
+                                exception.getMessage()),
+                        () -> assertTrue(exception.getMessage().contains("It reads tenant"),
+                                exception.getMessage()),
+                        () -> assertTrue(exception.getMessage().contains("currency"),
+                                exception.getMessage()));
+            }
+
+            @Test
+            @DisplayName("does not offer the columns of a table only a subquery reads")
+            void shouldNotOfferColumnsOutOfScope() {
+                // The scope is what the statement selects *from*. A table reached only inside a
+                // subquery is not in it, so a parameter compared against one of its columns has
+                // nothing to match — while the parameters of the outer table are unaffected.
+                final var exception = assertThrows(UntypedParameterException.class,
+                        () -> withSchema(TENANT, "create table audit (slug varchar(64) not null)")
+                                .configureParameters(statement(), SOURCE,
+                                        "select currency from tenant where id = :id "
+                                                + "and currency in (select slug from audit where slug = :slug)",
+                                        indices("id", "slug")));
+
+                assertAll(
+                        () -> assertTrue(exception.getMessage().contains("slug"), exception.getMessage()),
+                        () -> assertTrue(exception.getMessage().contains("It reads tenant"),
+                                exception.getMessage()),
+                        // The outer parameter typed from the schema and is not among the complaints.
+                        () -> assertTrue(!exception.getMessage().contains("for: id"),
+                                exception.getMessage()));
+            }
+
+            @Test
+            @DisplayName("says when the statement reads from something it cannot list")
+            void shouldSayWhenTheScopeIsNotExhaustive() {
+                // A derived table in the FROM takes the whole statement out of inference, and the
+                // reason has nothing to do with the schema.
+                final var exception = assertThrows(UntypedParameterException.class,
+                        () -> withSchema(TENANT).configureParameters(statement(), SOURCE,
+                                "select currency from (select * from tenant) t where t.id = :id",
+                                indices("id")));
+
+                assertAll(
+                        () -> assertTrue(exception.getMessage().contains("subquery"),
+                                exception.getMessage()),
+                        () -> assertTrue(exception.getMessage().contains("every parameter here"),
+                                exception.getMessage()));
+            }
+
+        }
+
         @Test
         @DisplayName("a camelCase parameter names the snake_case column, as a record component does")
         void shouldTypeACamelCaseParameterFromASnakeCaseColumn() {


### PR DESCRIPTION
The message listed what the schema held and never mentioned the name, so a statement comparing ':tenantId' against a column called 'id' read as a schema that was short. A reader went to their migrations, then to schema.vendor, before it occurred to them that the name was the input — and both places they looked were in order.

It now states the rule and names what it matched against: the tables the statement reads and the columns they hold, so a parameter that is not among them is visible rather than deduced. The schema contents are printed only where they can still explain something, since after the columns are listed they point back at a schema that is not the problem.

Two boundaries get their own wording. A table reached only inside a subquery is not one of the statement's tables, and a statement selecting from a derived table has no scope to match against at all — neither has anything to do with the schema, which is what the old message implied.

The rule itself is now written down on the website and in the skill, since working it out took reading failures one build at a time.