### PR TITLE
fix!: order a method's parameters by the statement, not by the front …

### DIFF
--- a/.claude/skills/yosql/SKILL.md
+++ b/.claude/skills/yosql/SKILL.md
@@ -80,7 +80,8 @@ all** — name it accordingly, or set `type` explicitly.
 
 Named parameters are written `:name` and become method parameters in the order they first appear.
 That order comes from the SQL alone — a `parameters:` block naming some of them, or naming them in
-another order, does not move them.
+another order, does not move them. So a block only has to name what inference cannot reach: declare
+the one parameter the schema cannot type and let the rest infer, rather than writing out all six.
 
 The generator needs a Java type for each one. It takes it from the front matter, from the component
 of the same name on the `resultRowType` record, or from the column the parameter is named after:

--- a/.claude/skills/yosql/SKILL.md
+++ b/.claude/skills/yosql/SKILL.md
@@ -79,6 +79,8 @@ all** — name it accordingly, or set `type` explicitly.
 ## Parameters
 
 Named parameters are written `:name` and become method parameters in the order they first appear.
+That order comes from the SQL alone — a `parameters:` block naming some of them, or naming them in
+another order, does not move them.
 
 The generator needs a Java type for each one. It takes it from the front matter, from the component
 of the same name on the `resultRowType` record, or from the column the parameter is named after:

--- a/docs/content/installation/upgrading.md
+++ b/docs/content/installation/upgrading.md
@@ -145,6 +145,32 @@ worked can start failing. If you see it, rename whichever of the two names is yo
 another package, or turn off
 [generateInterfaces](/configuration/repositories/generateinterfaces/).
 
+### A `parameters:` block no longer changes the order of a method
+
+A generated method takes its parameters in the order the statement binds them. Declaring some of
+them used to move those to the front:
+
+```sql
+-- parameters:
+--   tenantId: uuid
+select id from restore where id = :id and tenant_id = :tenantId
+```
+
+```java
+findWithdrawableRestore(UUID tenantId, UUID id)   // before
+findWithdrawableRestore(UUID id, UUID tenantId)   // now, and what the SQL says
+```
+
+**Check any statement whose block names fewer parameters than the statement binds, or names them in
+an order the SQL does not use.** Where the moved parameters have different types, your call sites
+stop compiling and the compiler shows you every one. Where they share a type — two `UUID`s, as
+above — they compile before and after, and the arguments were going in the wrong way round before
+this release. That is the case worth looking for: a query returns nothing where it should return a
+row, and a write touches the wrong row.
+
+A block naming every parameter in the order the SQL binds them is unaffected, which is how most are
+written.
+
 ### The build says which columns it cannot type
 
 Alongside the table count, a run now names the columns the schema holds and cannot give a Java type:

--- a/docs/content/sql/schema.md
+++ b/docs/content/sql/schema.md
@@ -167,6 +167,20 @@ Two boundaries follow from "the tables the statement reads":
 The build says which of these it is when it cannot type a parameter, including the columns it
 matched against.
 
+A block only has to name what inference cannot reach. Declaring one parameter of six leaves the
+other five inferred, and the method's parameters stay in the order the statement binds them either
+way — so a statement with one awkward name keeps one line of front matter rather than six:
+
+```sql
+-- name: findOrderSuspensionsOfTenant
+-- returning: multiple
+-- parameters:
+--   tenantId: uuid
+select * from order_suspension
+where suspended_at > :suspendedAt
+  and order_id in (select id from placed_order where tenant_id = :tenantId)
+```
+
 ## Records come free too
 
 A result row type is usually a record whose components repeat, one by one, what the `select` list

--- a/docs/content/sql/sql-files.md
+++ b/docs/content/sql/sql-files.md
@@ -47,6 +47,11 @@ WHERE   id = :userId
 
 While parsing your `.sql` files, `YoSQL` will strip the SQL comment prefix (`--`) and read the remaining text as a YAML object. The available configuration options that can be used in the front matter, are listed under [SQL statement configuration](/configuration/sql/).
 
+The generated method takes its parameters in the order the statement binds them, by first
+occurrence. That is a property of the SQL, so it does not change with what the front matter says: a
+`parameters:` block naming some of them, or naming all of them in another order, still produces the
+same signature. Reordering a statement's placeholders does change it.
+
 ### Names a parameter cannot have
 
 A generated method declares a few variables of its own — the `Connection`, the `PreparedStatement`,

--- a/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/jul/JdbcJulWrite.java
+++ b/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/jul/JdbcJulWrite.java
@@ -27,12 +27,12 @@ public class JdbcJulWrite extends AbstractJulBenchmark implements Write {
 
     @Override
     public void updateOneToManyRelation() {
-        departmentRepository.updateDepartmentsOfCompany(2L, 1L, "benchmarks");
+        departmentRepository.updateDepartmentsOfCompany(2L, "benchmarks", 1L);
     }
 
     @Override
     public void updateSingleEntity() {
-        employeeRepository.updateEmployee(1L, 1L, "bob", "builder", "bob@example.com", 200L);
+        employeeRepository.updateEmployee(1L, "bob", "builder", "bob@example.com", 200L, 1L);
     }
 
     @Override

--- a/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/log4j/JdbcLog4jWrite.java
+++ b/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/log4j/JdbcLog4jWrite.java
@@ -29,12 +29,12 @@ public class JdbcLog4jWrite extends AbstractLog4jBenchmark implements Write {
 
     @Override
     public void updateOneToManyRelation() {
-        departmentRepository.updateDepartmentsOfCompany(2L, 1L, "benchmarks");
+        departmentRepository.updateDepartmentsOfCompany(2L, "benchmarks", 1L);
     }
 
     @Override
     public void updateSingleEntity() {
-        employeeRepository.updateEmployee(1L, 1L, "bob", "builder", "bob@example.com", 200L);
+        employeeRepository.updateEmployee(1L, "bob", "builder", "bob@example.com", 200L, 1L);
     }
 
     @Override

--- a/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/noop/JdbcWrite.java
+++ b/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/noop/JdbcWrite.java
@@ -29,12 +29,12 @@ public class JdbcWrite extends AbstractNoOpBenchmark implements Write {
 
     @Override
     public void updateOneToManyRelation() {
-        departmentRepository.updateDepartmentsOfCompany(2L, 1L, "benchmarks");
+        departmentRepository.updateDepartmentsOfCompany(2L, "benchmarks", 1L);
     }
 
     @Override
     public void updateSingleEntity() {
-        employeeRepository.updateEmployee(1L, 1L, "bob", "builder", "bob@example.com", 200L);
+        employeeRepository.updateEmployee(1L, "bob", "builder", "bob@example.com", 200L, 1L);
     }
 
     @Override

--- a/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/slf4j/JdbcSlf4jWrite.java
+++ b/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/slf4j/JdbcSlf4jWrite.java
@@ -29,12 +29,12 @@ public class JdbcSlf4jWrite extends AbstractSlf4jBenchmark implements Write {
 
     @Override
     public void updateOneToManyRelation() {
-        departmentRepository.updateDepartmentsOfCompany(2L, 1L, "benchmarks");
+        departmentRepository.updateDepartmentsOfCompany(2L, "benchmarks", 1L);
     }
 
     @Override
     public void updateSingleEntity() {
-        employeeRepository.updateEmployee(1L, 1L, "bob", "builder", "bob@example.com", 200L);
+        employeeRepository.updateEmployee(1L, "bob", "builder", "bob@example.com", 200L, 1L);
     }
 
     @Override

--- a/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/system/JdbcSystemWrite.java
+++ b/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/system/JdbcSystemWrite.java
@@ -30,12 +30,12 @@ public class JdbcSystemWrite extends AbstractSystemBenchmark implements Write {
 
     @Override
     public void updateOneToManyRelation() {
-        departmentRepository.updateDepartmentsOfCompany(2L, 1L, "benchmarks");
+        departmentRepository.updateDepartmentsOfCompany(2L, "benchmarks", 1L);
     }
 
     @Override
     public void updateSingleEntity() {
-        employeeRepository.updateEmployee(1L, 1L, "bob", "builder", "bob@example.com", 200L);
+        employeeRepository.updateEmployee(1L, "bob", "builder", "bob@example.com", 200L, 1L);
     }
 
     @Override

--- a/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/tinylog/JdbcTinylogWrite.java
+++ b/yosql-benchmarks/yosql-benchmarks-dao/src/main/java/wtf/metio/yosql/benchmark/dao/tinylog/JdbcTinylogWrite.java
@@ -29,12 +29,12 @@ public class JdbcTinylogWrite extends AbstractTinylogBenchmark implements Write 
 
     @Override
     public void updateOneToManyRelation() {
-        departmentRepository.updateDepartmentsOfCompany(2L, 1L, "benchmarks");
+        departmentRepository.updateDepartmentsOfCompany(2L, "benchmarks", 1L);
     }
 
     @Override
     public void updateSingleEntity() {
-        employeeRepository.updateEmployee(1L, 1L, "bob", "builder", "bob@example.com", 200L);
+        employeeRepository.updateEmployee(1L, "bob", "builder", "bob@example.com", 200L, 1L);
     }
 
     @Override

--- a/yosql-benchmarks/yosql-benchmarks-vs-jdbi/src/main/java/wtf/metio/yosql/benchmark/jdbi/yosql/YosqlWrite.java
+++ b/yosql-benchmarks/yosql-benchmarks-vs-jdbi/src/main/java/wtf/metio/yosql/benchmark/jdbi/yosql/YosqlWrite.java
@@ -29,13 +29,13 @@ public class YosqlWrite extends AbstractYosqlShootout implements Write {
     @Override
     @Benchmark
     public void updateOneToManyRelation() {
-        departments.updateDepartmentsOfCompany(2L, 1L, "benchmarks");
+        departments.updateDepartmentsOfCompany(2L, "benchmarks", 1L);
     }
 
     @Override
     @Benchmark
     public void updateSingleEntity() {
-        employees.updateEmployee(1L, 1L, "bob", "builder", "bob@example.com", 200L);
+        employees.updateEmployee(1L, "bob", "builder", "bob@example.com", 200L, 1L);
     }
 
     @Override

--- a/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurer.java
+++ b/yosql-codegen/src/main/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurer.java
@@ -26,6 +26,8 @@ import wtf.metio.yosql.models.immutables.SqlConfiguration;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.LinkedHashSet;
@@ -78,7 +80,7 @@ public final class DefaultMethodParameterConfigurer implements MethodParameterCo
         }
         rejectReservedNames(source, configuration, parameterIndices.keySet());
         final var declared = updateIndices(configuration.parameters(), parameterIndices);
-        final var all = addMissingParameters(declared, parameterIndices);
+        final var all = inSqlOrder(addMissingParameters(declared, parameterIndices));
         final var typed = inferTypes(all, configuration, source, sql);
         return SqlConfiguration.copyOf(configuration).withParameters(typed);
     }
@@ -303,6 +305,34 @@ public final class DefaultMethodParameterConfigurer implements MethodParameterCo
         return numbers.stream()
                 .mapToInt(Integer::intValue)
                 .toArray();
+    }
+
+    /**
+     * The order the statement binds them in, whichever of them the front matter happens to name.
+     *
+     * <p>A method's parameters are a property of its SQL — {@code :id} before {@code :slug} because
+     * the insert lists them that way — and the front matter is telling us types. Appending the ones
+     * it did not name put every declared parameter first, so a block naming one of six moved that
+     * one to the front of a method whose SQL had not changed. Where the moved parameter shares a
+     * type with the one it displaced, every call site still compiles and now passes them the wrong
+     * way round.</p>
+     *
+     * <p>By first occurrence, since a parameter bound more than once is one method parameter and
+     * the earliest position is the one a reader of the statement sees.</p>
+     */
+    private static List<SqlParameter> inSqlOrder(final List<SqlParameter> parameters) {
+        return parameters.stream()
+                .sorted(Comparator.comparingInt(DefaultMethodParameterConfigurer::firstIndex))
+                .toList();
+    }
+
+    private static int firstIndex(final SqlParameter parameter) {
+        return parameter.indices()
+                .filter(indices -> indices.length > 0)
+                .map(indices -> Arrays.stream(indices).min().orElse(Integer.MAX_VALUE))
+                // Nothing says where it goes, so it keeps its place at the back rather than
+                // jumping to the front of a sort that cannot see it.
+                .orElse(Integer.MAX_VALUE);
     }
 
     private static List<SqlParameter> addMissingParameters(final List<SqlParameter> parameters, final Map<String, List<Integer>> indices) {

--- a/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurerTest.java
+++ b/yosql-codegen/src/test/java/wtf/metio/yosql/codegen/files/DefaultMethodParameterConfigurerTest.java
@@ -274,6 +274,73 @@ class DefaultMethodParameterConfigurerTest {
     }
 
     @Nested
+    @DisplayName("orders the method by the statement, not by the front matter")
+    class Order {
+
+        private DefaultMethodParameterConfigurer withSchema(final String... ddl) {
+            return new DefaultMethodParameterConfigurer(
+                    LoggingObjectMother.logger(),
+                    OrchestrationObjectMother.executionErrors(),
+                    LoggingObjectMother.messages(),
+                    new RecordScanner(
+                            FilesConfiguration.builder().setSourceDirectory(sources).build(),
+                            new JavaSourceParser()),
+                    Schemas.of(java.util.Arrays.stream(ddl)
+                            .map(sql -> new Schemas.VendorStatement(java.util.Optional.empty(), sql))
+                            .toList()));
+        }
+
+        @Test
+        @DisplayName("a block naming one parameter leaves the rest where the SQL puts them")
+        void shouldNotMoveADeclaredParameterToTheFront() {
+            // The dangerous shape: two parameters of one type, one of them declared. Reordering
+            // them leaves every call site compiling and passing them the wrong way round.
+            // 'id' inferred from the schema, 'tenantId' declared — the partial block.
+            final var configured = withSchema("""
+                    create table restore (id uuid not null primary key, tenant_id uuid not null)""")
+                    .configureParameters(
+                            statement(parameter("tenantId", "java.util.UUID")), SOURCE,
+                            "select * from restore where id = :id and tenant_id = :tenantId",
+                            indices("id", "tenantId"));
+
+            assertEquals(List.of("id", "tenantId"), names(configured));
+        }
+
+        @Test
+        @DisplayName("a block written out of order does not reorder the method either")
+        void shouldFollowTheSqlRatherThanTheBlock() {
+            final var configured = configurer.configureParameters(
+                    statement(parameter("slug", "java.lang.String"), parameter("id", "java.util.UUID")),
+                    SOURCE, "insert into tenant (id, slug) values (:id, :slug)", indices("id", "slug"));
+
+            assertEquals(List.of("id", "slug"), names(configured));
+        }
+
+        @Test
+        @DisplayName("a parameter bound twice takes the place it is first bound in")
+        void shouldUseTheFirstOccurrence() {
+            // Written out by hand: the helper above gives each name one index, and the point here
+            // is a name bound at two positions.
+            final var bound = new LinkedHashMap<String, List<Integer>>();
+            bound.put("slug", List.of(1, 3));
+            bound.put("id", List.of(2));
+
+            final var configured = configurer.configureParameters(
+                    statement(parameter("id", "java.util.UUID"), parameter("slug", "java.lang.String")),
+                    SOURCE, "select * from tenant where slug = :slug or id = :id or slug = :slug", bound);
+
+            assertEquals(List.of("slug", "id"), names(configured));
+        }
+
+        private static List<String> names(final SqlConfiguration configuration) {
+            return configuration.parameters().stream()
+                    .map(parameter -> parameter.name().orElseThrow())
+                    .toList();
+        }
+
+    }
+
+    @Nested
     @DisplayName("takes the type of the column the parameter is named after")
     class FromSchema {
 


### PR DESCRIPTION
…matter

Declared parameters were kept in the order the front matter listed them and the inferred ones appended after, so a block naming one parameter of six moved that one to the front of a method whose SQL had not changed. Where it shares a type with the parameter it displaced — two UUIDs, an id and a tenant id — every call site still compiles and passes them the wrong way round. A query then returns nothing where a row was expected, and a write touches the wrong row.

A method's parameters are a property of its SQL, which is what the documentation has always said they were: `:id` before `:slug` because the insert lists them that way. The front matter is telling us types. They are now ordered by first occurrence in the statement, whichever of them anything declared.

BREAKING CHANGE: a statement whose `parameters:` block names fewer parameters than the statement binds, or names them in an order the SQL does not use, changes the order of its generated method. Where the types differ the call sites stop compiling; where they match, the arguments were going in the wrong way round before this.